### PR TITLE
Modernization and ambiguity reduction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,29 @@
 
 # Debug files
 *.dSYM/
+
+# toptal/gitignore/templates/CMake.gitignore
+
+CMakeLists.txt.user
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Testing
+Makefile
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+_deps
+
+build
+
+# toptal/gitignore/templates/VisualStudioCode.gitignore
+
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+
+!.vscode/*.code-snippets

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+    "C_Cpp.default.configurationProvider": "ms-vscode.cmake-tools",
+    "cSpell.words": [
+        "cvector"
+    ],
+    "files.associations": {
+        "cvector.h": "c"
+    }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,6 +5,7 @@
     ],
     "files.associations": {
         "cvector.h": "c",
-        "stddef.h": "c"
+        "stddef.h": "c",
+        "type_traits": "c"
     }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,7 @@
         "cvector"
     ],
     "files.associations": {
-        "cvector.h": "c"
+        "cvector.h": "c",
+        "stddef.h": "c"
     }
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,4 @@
 cmake_minimum_required(VERSION 3.0.0)
 project(c-vector VERSION 0.1.0)
 
-add_library(c-vector cvector.c)
-add_executable (c-vector-example cvector.c example.c)
-
-set(CPACK_PROJECT_NAME ${PROJECT_NAME})
-set(CPACK_PROJECT_VERSION ${PROJECT_VERSION})
-include(CPack)
+add_executable (c-vector-example example.c)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.0.0)
+project(c-vector VERSION 0.1.0)
+
+add_library(c-vector cvector.c)
+add_executable (c-vector-example cvector.c example.c)
+
+set(CPACK_PROJECT_NAME ${PROJECT_NAME})
+set(CPACK_PROJECT_VERSION ${PROJECT_VERSION})
+include(CPack)

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ int main(int argc, char *argv[]) {
      * and capacity of 0. additionally, vector_begin and vector_end will
      * return NULL on a NULL vector.
      */
-    cvector_VECTOR(int) v = NULL;
+    cvector_vector_type(int) v = NULL;
 
     (void)argc;
     (void)argv;

--- a/README.md
+++ b/README.md
@@ -32,51 +32,52 @@ is thus header only. Usage is simple:
 
 int main(int argc, char *argv[]) {
 
-  /* this is the variable that will store the array, you can have
-   * a vector of any type! For example, you may write float *v = NULL,
-   * and you'd have a vector of floats :-). NULL will have a size
-   * and capacity of 0. additionally, vector_begin and vector_end will
-   * return NULL on a NULL vector.
-   */
-  cvector_VECTOR(int) v = NULL;
+    /* this is the variable that will store the array, you can have
+     * a vector of any type! For example, you may write float *v = NULL,
+     * and you'd have a vector of floats :-). NULL will have a size
+     * and capacity of 0. additionally, vector_begin and vector_end will
+     * return NULL on a NULL vector.
+     */
+    cvector_VECTOR(int) v = NULL;
 
-  (void)argc;
-  (void)argv;
+    (void)argc;
+    (void)argv;
 
-  /* add some elements to the back */
-  cvector_push_back(v, 10);
-  cvector_push_back(v, 20);
-  cvector_push_back(v, 30);
+    /* add some elements to the back */
+    cvector_push_back(v, 10);
+    cvector_push_back(v, 20);
+    cvector_push_back(v, 30);
 
-  /* and remove one too */
-  cvector_pop_back(v);
+    /* and remove one too */
+    cvector_pop_back(v);
 
-  /* print out some stats about the vector */
-  printf("pointer : %p\n", (void *)v);
-  printf("capacity: %lu\n", cvector_capacity(v));
-  printf("size    : %lu\n", cvector_size(v));
+    /* print out some stats about the vector */
+    printf("pointer : %p\n", (void *)v);
+    printf("capacity: %lu\n", cvector_capacity(v));
+    printf("size    : %lu\n", cvector_size(v));
 
-  /* iterator over the vector using "iterator" style */
-  if (v) {
-    int *it;
-    int i = 0;
-    for (it = cvector_begin(v); it != cvector_end(v); ++it) {
-      printf("v[%d] = %d\n", i, *it);
-      ++i;
+    /* iterator over the vector using "iterator" style */
+    if (v) {
+        int *it;
+        int i = 0;
+        for (it = cvector_begin(v); it != cvector_end(v); ++it) {
+            printf("v[%d] = %d\n", i, *it);
+            ++i;
+        }
     }
-  }
 
-  /* iterator over the vector standard indexing too! */
-  if (v) {
-    size_t i;
-    for (i = 0; i < cvector_size(v); ++i) {
-      printf("v[%lu] = %d\n", i, v[i]);
+    /* iterator over the vector standard indexing too! */
+    if (v) {
+        size_t i;
+        for (i = 0; i < cvector_size(v); ++i) {
+            printf("v[%lu] = %d\n", i, v[i]);
+        }
     }
-  }
 
-  /* well, we don't have destructors, so let's clean things up */
-  cvector_free(v);
+    /* well, we don't have destructors, so let's clean things up */
+    cvector_free(v);
 
-  return 0;
+    return 0;
 }
+
 ```

--- a/README.md
+++ b/README.md
@@ -19,60 +19,64 @@ vector.
 
 To allow the code to be maximally generic, it is implemented as all macros, and
 is thus header only. Usage is simple:
+```c
+/* if this is defined, then the vector will double in capacity each
+ * time it runs out of space. if it is not defined, then the vector will
+ * be conservative, and will have a capcity no larger than necessary.
+ * having this defined will minimize how often realloc gets called.
+ */
+#define CVECTOR_LOGARITHMIC_GROWTH
 
-	/* if this is defined, then the vector will double in capacity each 
-	 * time it runs out of space. if it is not defined, then the vector will
-	 * be conservative, and will have a capcity no larger than necessary.
-	 * having this defined will minimize how often realloc gets called.
-	 */
-	#define LOGARITHMIC_GROWTH
+#include "cvector.h"
+#include <stdio.h>
 
-	#include "vector.h"
-	#include <stdio.h>
+int main(int argc, char *argv[]) {
 
-	int main(int argc, char *argv[]) {
+  /* this is the variable that will store the array, you can have
+   * a vector of any type! For example, you may write float *v = NULL,
+   * and you'd have a vector of floats :-). NULL will have a size
+   * and capacity of 0. additionally, vector_begin and vector_end will
+   * return NULL on a NULL vector.
+   */
+  cvector_VECTOR(int) v = NULL;
 
-		/* this is the variable that will store the array, you can have
-		 * a vector of any type! For example, you may write float *v = NULL, 
-		 * and you'd have a vector of floats :-). NULL will have a size 
-		 * and capacity of 0. additionally, vector_begin and vector_end will 
-		 * return NULL on a NULL vector.
-		 */
-		int *v = NULL;
-		
-		/* add some elements to the back */
-		vector_push_back(v, 10);
-		vector_push_back(v, 20);
-		vector_push_back(v, 30);
+  (void)argc;
+  (void)argv;
 
-		/* and remove one too */
-		vector_pop_back(v);
+  /* add some elements to the back */
+  cvector_push_back(v, 10);
+  cvector_push_back(v, 20);
+  cvector_push_back(v, 30);
 
-		/* print out some stats about the vector */
-		printf("pointer : %p\n",  (void *)v);
-		printf("capacity: %lu\n", vector_capacity(v));
-		printf("size    : %lu\n", vector_size(v));
+  /* and remove one too */
+  cvector_pop_back(v);
 
-		/* iterator over the vector using "iterator" style */
-		if(v) {
-			int * it;
-			int i = 0;
-			for(it = vector_begin(v); it != vector_end(v); ++it) {
-				printf("v[%lu] = %d\n", i, *it);
-				++i;
-			}
-		}
-		
-		/* iterator over the vector standard indexing too! */
-		if(v) {
-			size_t i;
-			for(i = 0; i < vector_size(v); ++i) {
-				printf("v[%d] = %d\n", i, v[i]);
-			}
-		}		
+  /* print out some stats about the vector */
+  printf("pointer : %p\n", (void *)v);
+  printf("capacity: %lu\n", cvector_capacity(v));
+  printf("size    : %lu\n", cvector_size(v));
 
-		/* well, we don't have destructors, so let's clean things up */
-		vector_free(v);
-		
-		return 0;
-	}
+  /* iterator over the vector using "iterator" style */
+  if (v) {
+    int *it;
+    int i = 0;
+    for (it = cvector_begin(v); it != cvector_end(v); ++it) {
+      printf("v[%d] = %d\n", i, *it);
+      ++i;
+    }
+  }
+
+  /* iterator over the vector standard indexing too! */
+  if (v) {
+    size_t i;
+    for (i = 0; i < cvector_size(v); ++i) {
+      printf("v[%lu] = %d\n", i, v[i]);
+    }
+  }
+
+  /* well, we don't have destructors, so let's clean things up */
+  cvector_free(v);
+
+  return 0;
+}
+```

--- a/cvector.c
+++ b/cvector.c
@@ -1,0 +1,1 @@
+#include "cvector.h"

--- a/cvector.c
+++ b/cvector.c
@@ -1,1 +1,0 @@
-#include "cvector.h"

--- a/cvector.h
+++ b/cvector.h
@@ -1,18 +1,27 @@
 
-#ifndef VECTOR_H_
-#define VECTOR_H_
+#ifndef __CVECTOR_H__
+#define __CVECTOR_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 #include <stddef.h> /* for size_t */
 #include <stdlib.h> /* for malloc/realloc/free */
 #include <assert.h> /* for assert */
 
 /**
- * @brief vector_set_capacity - For internal use, sets the capacity variable of the vector
+ * @brief cvector_VECTOR - The vector type used in this library  
+ */
+#define cvector_VECTOR(type) type *
+
+/**
+ * @brief cvector_set_capacity - For internal use, sets the capacity variable of the vector
  * @param vec - the vector
  * @param size - the new capacity to set
  * @return void
  */
-#define vector_set_capacity(vec, size)   \
+#define cvector_set_capacity(vec, size)   \
 do {                                     \
 	if(vec) {                            \
 		((size_t *)(vec))[-1] = (size);  \
@@ -20,12 +29,12 @@ do {                                     \
 } while(0)
 
 /**
- * @brief vector_set_size - For internal use, sets the size variable of the vector
+ * @brief cvector_set_size - For internal use, sets the size variable of the vector
  * @param vec - the vector
  * @param size - the new capacity to set
  * @return void
  */
-#define vector_set_size(vec, size)      \
+#define cvector_set_size(vec, size)      \
 do {                                    \
 	if(vec) {                           \
 		((size_t *)(vec))[-2] = (size); \
@@ -33,74 +42,74 @@ do {                                    \
 } while(0)
 
 /**
- * @brief vector_capacity - gets the current capacity of the vector
+ * @brief cvector_capacity - gets the current capacity of the vector
  * @param vec - the vector
  * @return the capacity as a size_t
  */
-#define vector_capacity(vec) \
+#define cvector_capacity(vec) \
 	((vec) ? ((size_t *)(vec))[-1] : (size_t)0)
 
 /**
- * @brief vector_size - gets the current size of the vector
+ * @brief cvector_size - gets the current size of the vector
  * @param vec - the vector
  * @return the size as a size_t
  */
-#define vector_size(vec) \
+#define cvector_size(vec) \
 	((vec) ? ((size_t *)(vec))[-2] : (size_t)0)
 
 /**
- * @brief vector_empty - returns non-zero if the vector is empty
+ * @brief cvector_empty - returns non-zero if the vector is empty
  * @param vec - the vector
  * @return non-zero if empty, zero if non-empty
  */
-#define vector_empty(vec) \
-	(vector_size(vec) == 0)
+#define cvector_empty(vec) \
+	(cvector_size(vec) == 0)
 
 /**
- * @brief vector_grow - For internal use, ensures that the vector is at least <count> elements big
+ * @brief cvector_grow - For internal use, ensures that the vector is at least <count> elements big
  * @param vec - the vector
  * @param size - the new capacity to set
  * @return void
  */
-#define vector_grow(vec, count) \
+#define cvector_grow(vec, count) \
 do {                                                                                    \
 	if(!(vec)) {                                                                        \
 		size_t *__p = malloc((count) * sizeof(*(vec)) + (sizeof(size_t) * 2));          \
 		assert(__p);                                                                    \
 		(vec) = (void *)(&__p[2]);                                                      \
-		vector_set_capacity((vec), (count));                                            \
-		vector_set_size((vec), 0);                                                      \
+		cvector_set_capacity((vec), (count));                                            \
+		cvector_set_size((vec), 0);                                                      \
 	} else {                                                                            \
 		size_t *__p1 = &((size_t *)(vec))[-2];                                          \
 		size_t *__p2 = realloc(__p1, ((count) * sizeof(*(vec))+ (sizeof(size_t) * 2))); \
 		assert(__p2);                                                                   \
 		(vec) = (void *)(&__p2[2]);                                                     \
-		vector_set_capacity((vec), (count));                                            \
+		cvector_set_capacity((vec), (count));                                            \
 	}                                                                                   \
 } while(0)
 
 /**
- * @brief vector_pop_back - removes the last element from the vector
+ * @brief cvector_pop_back - removes the last element from the vector
  * @param vec - the vector
  * @return void
  */
-#define vector_pop_back(vec) \
+#define cvector_pop_back(vec) \
 do {                                              \
-	vector_set_size((vec), vector_size(vec) - 1); \
+	cvector_set_size((vec), cvector_size(vec) - 1); \
 } while(0)
 
 /**
- * @brief vector_erase - removes the element at index i from the vector
+ * @brief cvector_erase - removes the element at index i from the vector
  * @param vec - the vector
  * @param i - index of element to remove
  * @return void
  */
-#define vector_erase(vec, i) \
+#define cvector_erase(vec, i) \
 do {                                                   \
 	if (vec) {                                         \
-		const size_t __sz = vector_size(vec);          \
+		const size_t __sz = cvector_size(vec);          \
 		if ((i) < __sz) {                              \
-			vector_set_size((vec), __sz - 1);          \
+			cvector_set_size((vec), __sz - 1);          \
 			size_t __x;                                \
 			for (__x = (i); __x < (__sz - 1); ++__x) { \
 				(vec)[__x] = (vec)[__x + 1];           \
@@ -110,11 +119,11 @@ do {                                                   \
 } while(0)
 
 /**
- * @brief vector_free - frees all memory associated with the vector
+ * @brief cvector_free - frees all memory associated with the vector
  * @param vec - the vector
  * @return void
  */
-#define vector_free(vec) \
+#define cvector_free(vec) \
 do { \
 	if(vec) {                                \
 		size_t *p1 = &((size_t *)(vec))[-2]; \
@@ -123,52 +132,62 @@ do { \
 } while(0)
 
 /**
- * @brief vector_begin - returns an iterator to first element of the vector
+ * @brief cvector_begin - returns an iterator to first element of the vector
  * @param vec - the vector
  * @return a pointer to the first element (or NULL)
  */
-#define vector_begin(vec) \
+#define cvector_begin(vec) \
 	(vec)
 
 /**
- * @brief vector_end - returns an iterator to one past the last element of the vector
+ * @brief cvector_end - returns an iterator to one past the last element of the vector
  * @param vec - the vector
  * @return a pointer to one past the last element (or NULL)
  */
-#define vector_end(vec) \
-	((vec) ? &((vec)[vector_size(vec)]) : NULL)
+#define cvector_end(vec) \
+	((vec) ? &((vec)[cvector_size(vec)]) : NULL)
 
+
+#ifdef CVECTOR_LOGARITHMIC_GROWTH // user request to use logarithmic growth algorithm
 
 /**
- * @brief vector_push_back - adds an element to the end of the vector
+ * @brief cvector_push_back - adds an element to the end of the vector
  * @param vec - the vector
  * @param value - the value to add 
  * @return void
  */
-#ifdef LOGARITHMIC_GROWTH
-
-#define vector_push_back(vec, value) \
+#define cvector_push_back(vec, value) \
 do {                                                        \
-	size_t __cap = vector_capacity(vec);                    \
-	if(__cap <= vector_size(vec)) {                         \
-		vector_grow((vec), !__cap ? __cap + 1 : __cap * 2); \
+	size_t __cap = cvector_capacity(vec);                    \
+	if(__cap <= cvector_size(vec)) {                         \
+		cvector_grow((vec), !__cap ? __cap + 1 : __cap * 2); \
 	}                                                       \
-	vec[vector_size(vec)] = (value);                        \
-	vector_set_size((vec), vector_size(vec) + 1);           \
+	vec[cvector_size(vec)] = (value);                        \
+	cvector_set_size((vec), cvector_size(vec) + 1);           \
 } while(0)
 
 #else
 
-#define vector_push_back(vec, value) \
+/**
+ * @brief cvector_push_back - adds an element to the end of the vector
+ * @param vec - the vector
+ * @param value - the value to add 
+ * @return void
+ */
+#define cvector_push_back(vec, value) \
 do {                                              \
-	size_t __cap = vector_capacity(vec);          \
-	if(__cap <= vector_size(vec)) {               \
-		vector_grow((vec), __cap + 1);            \
+	size_t __cap = cvector_capacity(vec);          \
+	if(__cap <= cvector_size(vec)) {               \
+		cvector_grow((vec), __cap + 1);            \
 	}                                             \
-	vec[vector_size(vec)] = (value);              \
-	vector_set_size((vec), vector_size(vec) + 1); \
+	vec[cvector_size(vec)] = (value);              \
+	cvector_set_size((vec), cvector_size(vec) + 1); \
 } while(0)
 
-#endif
+#endif /* CVECTOR_LOGARITHMIC_GROWTH */
 
-#endif
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* __CVECTOR_H__ */

--- a/cvector.h
+++ b/cvector.h
@@ -1,10 +1,6 @@
 
-#ifndef __CVECTOR_H__
-#define __CVECTOR_H__
-
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
+#ifndef CVECTOR_H_
+#define CVECTOR_H_
 
 #include <stddef.h> /* for size_t */
 #include <stdlib.h> /* for malloc/realloc/free */
@@ -186,8 +182,4 @@ do {                                              \
 
 #endif /* CVECTOR_LOGARITHMIC_GROWTH */
 
-#ifdef __cplusplus
-}
-#endif /* __cplusplus */
-
-#endif /* __CVECTOR_H__ */
+#endif /* CVECTOR_H_ */

--- a/cvector.h
+++ b/cvector.h
@@ -7,9 +7,9 @@
 #include <assert.h> /* for assert */
 
 /**
- * @brief cvector_VECTOR - The vector type used in this library  
+ * @brief cvector_vector_type - The vector type used in this library  
  */
-#define cvector_VECTOR(type) type *
+#define cvector_vector_type(type) type *
 
 /**
  * @brief cvector_set_capacity - For internal use, sets the capacity variable of the vector

--- a/example.c
+++ b/example.c
@@ -10,50 +10,50 @@
 
 int main(int argc, char *argv[]) {
 
-  /* this is the variable that will store the array, you can have
-   * a vector of any type! For example, you may write float *v = NULL,
-   * and you'd have a vector of floats :-). NULL will have a size
-   * and capacity of 0. additionally, vector_begin and vector_end will
-   * return NULL on a NULL vector.
-   */
-  cvector_VECTOR(int) v = NULL;
+    /* this is the variable that will store the array, you can have
+     * a vector of any type! For example, you may write float *v = NULL,
+     * and you'd have a vector of floats :-). NULL will have a size
+     * and capacity of 0. additionally, vector_begin and vector_end will
+     * return NULL on a NULL vector.
+     */
+    cvector_VECTOR(int) v = NULL;
 
-  (void)argc;
-  (void)argv;
+    (void)argc;
+    (void)argv;
 
-  /* add some elements to the back */
-  cvector_push_back(v, 10);
-  cvector_push_back(v, 20);
-  cvector_push_back(v, 30);
+    /* add some elements to the back */
+    cvector_push_back(v, 10);
+    cvector_push_back(v, 20);
+    cvector_push_back(v, 30);
 
-  /* and remove one too */
-  cvector_pop_back(v);
+    /* and remove one too */
+    cvector_pop_back(v);
 
-  /* print out some stats about the vector */
-  printf("pointer : %p\n", (void *)v);
-  printf("capacity: %lu\n", cvector_capacity(v));
-  printf("size    : %lu\n", cvector_size(v));
+    /* print out some stats about the vector */
+    printf("pointer : %p\n", (void *)v);
+    printf("capacity: %lu\n", cvector_capacity(v));
+    printf("size    : %lu\n", cvector_size(v));
 
-  /* iterator over the vector using "iterator" style */
-  if (v) {
-    int *it;
-    int i = 0;
-    for (it = cvector_begin(v); it != cvector_end(v); ++it) {
-      printf("v[%d] = %d\n", i, *it);
-      ++i;
+    /* iterator over the vector using "iterator" style */
+    if (v) {
+        int *it;
+        int i = 0;
+        for (it = cvector_begin(v); it != cvector_end(v); ++it) {
+            printf("v[%d] = %d\n", i, *it);
+            ++i;
+        }
     }
-  }
 
-  /* iterator over the vector standard indexing too! */
-  if (v) {
-    size_t i;
-    for (i = 0; i < cvector_size(v); ++i) {
-      printf("v[%lu] = %d\n", i, v[i]);
+    /* iterator over the vector standard indexing too! */
+    if (v) {
+        size_t i;
+        for (i = 0; i < cvector_size(v); ++i) {
+            printf("v[%lu] = %d\n", i, v[i]);
+        }
     }
-  }
 
-  /* well, we don't have destructors, so let's clean things up */
-  cvector_free(v);
+    /* well, we don't have destructors, so let's clean things up */
+    cvector_free(v);
 
-  return 0;
+    return 0;
 }

--- a/example.c
+++ b/example.c
@@ -16,7 +16,7 @@ int main(int argc, char *argv[]) {
      * and capacity of 0. additionally, vector_begin and vector_end will
      * return NULL on a NULL vector.
      */
-    cvector_VECTOR(int) v = NULL;
+    cvector_vector_type(int) v = NULL;
 
     (void)argc;
     (void)argv;

--- a/example.c
+++ b/example.c
@@ -1,59 +1,59 @@
-	/* if this is defined, then the vector will double in capacity each 
-	 * time it runs out of space. if it is not defined, then the vector will
-	 * be conservative, and will have a capcity no larger than necessary.
-	 * having this defined will minimize how often realloc gets called.
-	 */
-	#define LOGARITHMIC_GROWTH
+/* if this is defined, then the vector will double in capacity each
+ * time it runs out of space. if it is not defined, then the vector will
+ * be conservative, and will have a capcity no larger than necessary.
+ * having this defined will minimize how often realloc gets called.
+ */
+#define CVECTOR_LOGARITHMIC_GROWTH
 
-	#include "vector.h"
-	#include <stdio.h>
+#include "cvector.h"
+#include <stdio.h>
 
-	int main(int argc, char *argv[]) {
+int main(int argc, char *argv[]) {
 
-		/* this is the variable that will store the array, you can have
-		 * a vector of any type! For example, you may write float *v = NULL, 
-		 * and you'd have a vector of floats :-). NULL will have a size 
-		 * and capacity of 0. additionally, vector_begin and vector_end will 
-		 * return NULL on a NULL vector.
-		 */
-		int *v = NULL;
-		
-		(void)argc;
-		(void)argv;		
+  /* this is the variable that will store the array, you can have
+   * a vector of any type! For example, you may write float *v = NULL,
+   * and you'd have a vector of floats :-). NULL will have a size
+   * and capacity of 0. additionally, vector_begin and vector_end will
+   * return NULL on a NULL vector.
+   */
+  cvector_VECTOR(int) v = NULL;
 
-		/* add some elements to the back */
-		vector_push_back(v, 10);
-		vector_push_back(v, 20);
-		vector_push_back(v, 30);
+  (void)argc;
+  (void)argv;
 
-		/* and remove one too */
-		vector_pop_back(v);
+  /* add some elements to the back */
+  cvector_push_back(v, 10);
+  cvector_push_back(v, 20);
+  cvector_push_back(v, 30);
 
-		/* print out some stats about the vector */
-		printf("pointer : %p\n",  (void *)v);
-		printf("capacity: %lu\n", vector_capacity(v));
-		printf("size    : %lu\n", vector_size(v));
+  /* and remove one too */
+  cvector_pop_back(v);
 
-		/* iterator over the vector using "iterator" style */
-		if(v) {
-			int * it;
-			int i = 0;
-			for(it = vector_begin(v); it != vector_end(v); ++it) {
-				printf("v[%d] = %d\n", i, *it);
-				++i;
-			}
-		}
-		
-		/* iterator over the vector standard indexing too! */
-		if(v) {
-			size_t i;
-			for(i = 0; i < vector_size(v); ++i) {
-				printf("v[%lu] = %d\n", i, v[i]);
-			}
-		}		
+  /* print out some stats about the vector */
+  printf("pointer : %p\n", (void *)v);
+  printf("capacity: %lu\n", cvector_capacity(v));
+  printf("size    : %lu\n", cvector_size(v));
 
-		/* well, we don't have destructors, so let's clean things up */
-		vector_free(v);
-		
-		return 0;
-	}
+  /* iterator over the vector using "iterator" style */
+  if (v) {
+    int *it;
+    int i = 0;
+    for (it = cvector_begin(v); it != cvector_end(v); ++it) {
+      printf("v[%d] = %d\n", i, *it);
+      ++i;
+    }
+  }
+
+  /* iterator over the vector standard indexing too! */
+  if (v) {
+    size_t i;
+    for (i = 0; i < cvector_size(v); ++i) {
+      printf("v[%lu] = %d\n", i, v[i]);
+    }
+  }
+
+  /* well, we don't have destructors, so let's clean things up */
+  cvector_free(v);
+
+  return 0;
+}


### PR DESCRIPTION
## Major changes
1. Use CMake as project making system.
2. Rewrite marco signatures in order to reduce ambiguity.
For example, `vector_set_capacity(vec, size)` is renamed to `cvector_set_capacity(vec, size)` to reduce the risk of clashing with other libraries.
Also, marco `LOGARITHMIC_GROWTH` is renamed to `CVECTOR_LOGARITHMIC_GROWTH` for the same reason.
3. `README.md` and `exmaple.c` are edited to suit the new source file.