### PR TITLE
Remove stddef.h include

### DIFF
--- a/cvector.h
+++ b/cvector.h
@@ -3,7 +3,6 @@
 #define CVECTOR_H_
 
 #include <assert.h> /* for assert */
-#include <stddef.h> /* for size_t */
 #include <stdlib.h> /* for malloc/realloc/free */
 
 /**


### PR DESCRIPTION
stddef.h is included to provide size_t, but stdlib.h also provides it