### PR TITLE
cvector.h: added cvector_copy() function

### DIFF
--- a/cvector.h
+++ b/cvector.h
@@ -182,4 +182,17 @@
 
 #endif /* CVECTOR_LOGARITHMIC_GROWTH */
 
+/**
+ * @brief cvector_copy - copy a vector
+ * @param from - the original vector
+ * @param to - destination to which the function copy to
+ * @return void
+ */
+#define cvector_copy(from, to)									\
+	do {														\
+		for(size_t i = 0; i < cvector_size(from); i++) {		\
+			cvector_push_back(to, from[i]);						\
+		}														\
+	} while (0)													\
+
 #endif /* CVECTOR_H_ */


### PR DESCRIPTION
I added a function `cvector_copy()` to solve #8 . I tried to use `memcpy()`, but it didn't work, so I use `cvector_push_back()`. The result is whether I make any change to the vector `from`, the vector `to` still remains the same.