### PR TITLE
add cvector_free_and_free_elements

### DIFF
--- a/cvector.h
+++ b/cvector.h
@@ -101,6 +101,24 @@
     } while (0)
 
 /**
+ * @brief cvector_free_with_mechanic - frees all memory associated with the vector and call free_func function on each item
+ * @param vec - the vector
+ * @param free_func - function used to free each element in the vector with one parameter which is the type of the element)
+ * @return void
+ */
+#define cvector_free_and_free_elements(vec, free_func)             \
+    do {                                                           \
+        if ((vec)) {                                               \
+            if (free_func) {                                       \
+                for (size_t i = 0; i < cvector_size((vec)); i++) { \
+                    free_func((vec)[i]);                           \
+                }                                                  \
+            }                                                      \
+            cvector_free(vec);                                     \
+        }                                                          \
+    } while (0)
+
+/**
  * @brief cvector_begin - returns an iterator to first element of the vector
  * @param vec - the vector
  * @return a pointer to the first element (or NULL)

--- a/test.c
+++ b/test.c
@@ -5,6 +5,7 @@
 #endif
 #include <assert.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 #define CVECTOR_LOGARITHMIC_GROWTH
 
@@ -15,6 +16,7 @@ int main() {
     cvector_vector_type(int) a = NULL;
     cvector_vector_type(int) b = NULL;
     cvector_vector_type(int) c = NULL;
+    cvector_vector_type(char*) str_vect = NULL;
 
     /* add some elements to the back */
     cvector_push_back(v, 10);
@@ -138,5 +140,19 @@ int main() {
     printf("c capacity: %zu\n", cvector_capacity(c));
     printf("c size        : %zu\n", cvector_size(c));
     cvector_free(c);
+
+
+    cvector_push_back(str_vect, strdup("Hello world"));
+    cvector_push_back(str_vect, strdup("Good  bye world"));
+    cvector_push_back(str_vect, strdup("not today"));
+
+    if (str_vect) {
+        size_t i;
+        for (i = 0; i < cvector_size(str_vect); ++i) {
+            printf("v[%zu] = %s\n", i, str_vect[i]);
+        }
+    }
+
+    cvector_free_and_free_elements(str_vect,free);
     return 0;
 }


### PR DESCRIPTION
This is a handy function for freeing each elements in case they are also allocated in the heap for example like string, and only using `cvector_free` won't each elements from the heap

```
#define CVECTOR_LOGARITHMIC_GROWTH

#include "cvector.h"
#include <stdio.h>
#include <stdlib.h>
int main(int argc, char *argv[]) {
    char str_1[] = "hello world";
    char str_2[] = "good bye world";
    char str_3[] = "not today" ;
    cvector_vector_type(char*) v = NULL;

    cvector_push_back(v, strdup(str_1));
    cvector_push_back(v, strdup(str_2));
    cvector_push_back(v, strdup(str_3));

    if (v) {
        size_t i;
        for (i = 0; i < cvector_size(v); ++i) {
            printf("v[%zu] = %s\n", i, v[i]);
        }
    }

    
    cvector_free(v);
   // cvector_free_and_free_elements(v,free);

    return 0;
}

```
in the example above, valgrind tells that there are memory leak when using `cvector_free` instead of `cvector_free_and_free_elements`