### PR TITLE
Modify local var names to avoid shadowing.

### DIFF
--- a/cvector.h
+++ b/cvector.h
@@ -62,12 +62,12 @@
  * @param n - Minimum capacity for the vector.
  * @return void
  */
-#define cvector_reserve(vec, capacity)         \
-    do {                                       \
-        size_t cv_cap = cvector_capacity(vec); \
-        if (cv_cap < (capacity)) {             \
-            cvector_grow((vec), (capacity));   \
-        }                                      \
+#define cvector_reserve(vec, capacity)           \
+    do {                                         \
+        size_t __cv_cap = cvector_capacity(vec); \
+        if (__cv_cap < (capacity)) {             \
+            cvector_grow((vec), (capacity));     \
+        }                                        \
     } while (0)
 
 /**
@@ -76,15 +76,15 @@
  * @param i - index of element to remove
  * @return void
  */
-#define cvector_erase(vec, i)                                                              \
-    do {                                                                                   \
-        if ((vec)) {                                                                       \
-            const size_t cv_sz = cvector_size(vec);                                        \
-            if ((i) < cv_sz) {                                                             \
-                cvector_set_size((vec), cv_sz - 1);                                        \
-                memmove((vec) + (i), (vec) + (i) + 1, sizeof(*(vec)) * (cv_sz - 1 - (i))); \
-            }                                                                              \
-        }                                                                                  \
+#define cvector_erase(vec, i)                                                                \
+    do {                                                                                     \
+        if ((vec)) {                                                                         \
+            const size_t __cv_sz = cvector_size(vec);                                        \
+            if ((i) < __cv_sz) {                                                             \
+                cvector_set_size((vec), __cv_sz - 1);                                        \
+                memmove((vec) + (i), (vec) + (i) + 1, sizeof(*(vec)) * (__cv_sz - 1 - (i))); \
+            }                                                                                \
+        }                                                                                    \
     } while (0)
 
 /**
@@ -147,14 +147,14 @@
  * @param value - the value to add
  * @return void
  */
-#define cvector_push_back(vec, value)                               \
-    do {                                                            \
-        size_t cv_cap = cvector_capacity(vec);                      \
-        if (cv_cap <= cvector_size(vec)) {                          \
-            cvector_grow((vec), cvector_compute_next_grow(cv_cap)); \
-        }                                                           \
-        vec[cvector_size(vec)] = (value);                           \
-        cvector_set_size((vec), cvector_size(vec) + 1);             \
+#define cvector_push_back(vec, value)                                 \
+    do {                                                              \
+        size_t __cv_cap = cvector_capacity(vec);                      \
+        if (__cv_cap <= cvector_size(vec)) {                          \
+            cvector_grow((vec), cvector_compute_next_grow(__cv_cap)); \
+        }                                                             \
+        vec[cvector_size(vec)] = (value);                             \
+        cvector_set_size((vec), cvector_size(vec) + 1);               \
     } while (0)
 
 /**
@@ -233,22 +233,22 @@
  * @param count - the new capacity to set
  * @return void
  */
-#define cvector_grow(vec, count)                                              \
-    do {                                                                      \
-        const size_t cv_sz = (count) * sizeof(*(vec)) + (sizeof(size_t) * 2); \
-        if ((vec)) {                                                          \
-            size_t *cv_p1 = &((size_t *)(vec))[-2];                           \
-            size_t *cv_p2 = cvector_clib_realloc(cv_p1, (cv_sz));             \
-            assert(cv_p2);                                                    \
-            (vec) = (void *)(&cv_p2[2]);                                      \
-            cvector_set_capacity((vec), (count));                             \
-        } else {                                                              \
-            size_t *cv_p = cvector_clib_malloc(cv_sz);                        \
-            assert(cv_p);                                                     \
-            (vec) = (void *)(&cv_p[2]);                                       \
-            cvector_set_capacity((vec), (count));                             \
-            cvector_set_size((vec), 0);                                       \
-        }                                                                     \
+#define cvector_grow(vec, count)                                                \
+    do {                                                                        \
+        const size_t __cv_sz = (count) * sizeof(*(vec)) + (sizeof(size_t) * 2); \
+        if ((vec)) {                                                            \
+            size_t *__cv_p1 = &((size_t *)(vec))[-2];                           \
+            size_t *__cv_p2 = cvector_clib_realloc(__cv_p1, (__cv_sz));         \
+            assert(__cv_p2);                                                    \
+            (vec) = (void *)(&__cv_p2[2]);                                      \
+            cvector_set_capacity((vec), (count));                               \
+        } else {                                                                \
+            size_t *__cv_p = cvector_clib_malloc(__cv_sz);                      \
+            assert(__cv_p);                                                     \
+            (vec) = (void *)(&__cv_p[2]);                                       \
+            cvector_set_capacity((vec), (count));                               \
+            cvector_set_size((vec), 0);                                         \
+        }                                                                       \
     } while (0)
 
 #endif /* CVECTOR_H_ */


### PR DESCRIPTION
## Example of Shadowing Problem

With the original definition, the following code
~~~c
cv_cap = 10;
cvector_reserve(vec, cv_cap);
~~~
would be expanded into
~~~c
do {
        size_t cv_cap = cvector_capacity(vec);
        if (cv_cap < (cv_cap)) {
                cvector_grow((vec), (cv_cap));
        }
} while (0)
~~~
which is incorrect.

Changing `cv_cap` to `__cv_cap` reduces the chance of such issues.