### PR TITLE
Add macro cvector_for_each_in

### DIFF
--- a/cvector_utils.h
+++ b/cvector_utils.h
@@ -2,6 +2,15 @@
 #define CVECTOR_UTILS_H_
 
 /**
+ * @brief cvector_for_each_in - for header to iterate over vector each element's address
+ * @param it - iterator of type pointer to vector element
+ * @param vec - the vector
+ * @return void
+ */
+#define cvector_for_each_in(it, vec) \
+    for (it = cvector_begin(vec); it < cvector_end(vec); it++)
+
+/**
  * @brief cvector_for_each - call function func on each element of the vector
  * @param vec - the vector
  * @param func - function to be called on each element that takes each element as argument


### PR DESCRIPTION
Add for loop header macro `cvector_for_each_in` to mimic frequently used range-based for cvectors. With this macro, it might be a good idea to remove `cvector_for_each` and `cvector_free_each_and_free`, because they break C89 compatibility. Declaring a variable is not permitted in C89. It might be a good idea to merge `cvector_for_each_in` if the other macros are removed, because cvector_utils.h only contains one macro.

Example usage of `cvector_for_each_in`:
```
int *it;
cvector_vector_type(int) v = NULL;

cvector_push_back(v, 10);
cvector_push_back(v, 12);

cvector_for_each_in(it, v) {
	printf("%d\n", *it);
}
```
The example prints out all members of cvector v.
