### PR TITLE
Feature: element destructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,16 +9,16 @@ It works by using the same trick as many allocators, which is to slightly
 allocate more data than requested, and using that extra padding in the front
 as storage for meta-data. Thus any non-null vector looks like this in memory:
 
-	+------+----------+---------+
-	| size | capacity | data... |
-	+------+----------+---------+
-	                  ^
-	                  | user's pointer
+	+-----------------+------+----------+---------+
+	| elem_destructor | size | capacity | data... |
+	+-----------------+------+----------+---------+
+	                                    ^
+	                                    | user's pointer
 
 Where the user is given a pointer to first element of `data`. This way the
 code has trivial access to the necessary meta-data, but the user need not be
-concerned with these details. The total overhead is `2 * sizeof(size_t)` per
-vector.
+concerned with these details. The total overhead is
+`2 * sizeof(size_t) + sizeof(void (*)(void *))` per vector.
 
 To allow the code to be maximally generic, it is implemented as all macros, and
 is thus header only. Usage is simple:

--- a/cvector.h
+++ b/cvector.h
@@ -24,6 +24,8 @@
 #define cvector_clib_realloc realloc
 #endif
 
+typedef void (*cvector_elem_destructor_t)(void *elem);
+
 /**
  * @brief cvector_vector_type - The vector type used in this library
  */
@@ -44,6 +46,30 @@
  */
 #define cvector_size(vec) \
     ((vec) ? ((size_t *)(vec))[-2] : (size_t)0)
+
+/**
+ * @brief cvector_set_elem_destructor - set the element destructor function
+ * used to clean up removed elements
+ * @param vec - the vector
+ * @return elem_destructor_fn - function pointer of type cvector_elem_destructor_t
+ * @return the function pointer elem_destructor_fn or NULL on error
+ */
+#define cvector_set_elem_destructor(vec, elem_destructor_fn)                                \
+    do {                                                                                    \
+        if (!(vec)) {                                                                       \
+            cvector_grow((vec), 0);                                                         \
+        }                                                                                   \
+        ((cvector_elem_destructor_t *)&(((size_t *)(vec))[-2]))[-1] = (elem_destructor_fn); \
+    } while (0)
+
+/**
+ * @brief cvector_elem_destructor - get the element destructor function used
+ * to clean up elements
+ * @param vec - the vector
+ * @return the function pointer as cvector_elem_destructor_t
+ */
+#define cvector_elem_destructor(vec) \
+    ((vec) ? (((cvector_elem_destructor_t *)&(((size_t *)(vec))[-2]))[-1]) : NULL)
 
 /**
  * @brief cvector_empty - returns non-zero if the vector is empty
@@ -92,12 +118,18 @@
  * @param vec - the vector
  * @return void
  */
-#define cvector_free(vec)                        \
-    do {                                         \
-        if ((vec)) {                             \
-            size_t *p1 = &((size_t *)(vec))[-2]; \
-            cvector_clib_free(p1);               \
-        }                                        \
+#define cvector_free(vec)                                                                                                           \
+    do {                                                                                                                            \
+        if ((vec)) {                                                                                                                \
+            size_t *p1__                                = (size_t *)&(((cvector_elem_destructor_t *)&(((size_t *)(vec))[-2]))[-1]); \
+            cvector_elem_destructor_t elem_destructor__ = cvector_elem_destructor((vec));                                           \
+            if (elem_destructor__) {                                                                                                \
+                size_t i__;                                                                                                         \
+                for (i__ = 0; i__ < cvector_size(vec); ++i__)                                                                       \
+                    elem_destructor__(&vec[i__]);                                                                                   \
+            }                                                                                                                       \
+            cvector_clib_free(p1__);                                                                                                \
+        }                                                                                                                           \
     } while (0)
 
 /**
@@ -181,9 +213,12 @@
  * @param vec - the vector
  * @return void
  */
-#define cvector_pop_back(vec)                           \
-    do {                                                \
-        cvector_set_size((vec), cvector_size(vec) - 1); \
+#define cvector_pop_back(vec)                                                         \
+    do {                                                                              \
+        cvector_elem_destructor_t elem_destructor__ = cvector_elem_destructor((vec)); \
+        if (elem_destructor__)                                                        \
+            elem_destructor__(&(vec)[cvector_size(vec) - 1]);                         \
+        cvector_set_size((vec), cvector_size(vec) - 1);                               \
     } while (0)
 
 /**
@@ -233,22 +268,22 @@
  * @param count - the new capacity to set
  * @return void
  */
-#define cvector_grow(vec, count)                                                \
-    do {                                                                        \
-        const size_t cv_sz__ = (count) * sizeof(*(vec)) + (sizeof(size_t) * 2); \
-        if ((vec)) {                                                            \
-            size_t *cv_p1__ = &((size_t *)(vec))[-2];                           \
-            size_t *cv_p2__ = cvector_clib_realloc(cv_p1__, (cv_sz__));         \
-            assert(cv_p2__);                                                    \
-            (vec) = (void *)(&cv_p2__[2]);                                      \
-            cvector_set_capacity((vec), (count));                               \
-        } else {                                                                \
-            size_t *cv_p__ = cvector_clib_malloc(cv_sz__);                      \
-            assert(cv_p__);                                                     \
-            (vec) = (void *)(&cv_p__[2]);                                       \
-            cvector_set_capacity((vec), (count));                               \
-            cvector_set_size((vec), 0);                                         \
-        }                                                                       \
+#define cvector_grow(vec, count)                                                                                  \
+    do {                                                                                                          \
+        const size_t cv_sz__ = (count) * sizeof(*(vec)) + sizeof(size_t) * 2 + sizeof(cvector_elem_destructor_t); \
+        if ((vec)) {                                                                                              \
+            cvector_elem_destructor_t *cv_p1__ = &((cvector_elem_destructor_t *)&((size_t *)(vec))[-2])[-1];      \
+            cvector_elem_destructor_t *cv_p2__ = cvector_clib_realloc(cv_p1__, cv_sz__);                          \
+            assert(cv_p2__);                                                                                      \
+            (vec) = (void *)&((size_t *)&cv_p2__[1])[2];                                                          \
+        } else {                                                                                                  \
+            cvector_elem_destructor_t *cv_p__ = cvector_clib_malloc(cv_sz__);                                     \
+            assert(cv_p__);                                                                                       \
+            (vec) = (void *)&((size_t *)&cv_p__[1])[2];                                                           \
+            cvector_set_size((vec), 0);                                                                           \
+            ((cvector_elem_destructor_t *)&(((size_t *)(vec))[-2]))[-1] = NULL;                                   \
+        }                                                                                                         \
+        cvector_set_capacity((vec), (count));                                                                     \
     } while (0)
 
 #endif /* CVECTOR_H_ */

--- a/cvector_utils.h
+++ b/cvector_utils.h
@@ -2,6 +2,15 @@
 #define CVECTOR_UTILS_H_
 
 /**
+ * @brief cvector_for_each_in - for header to iterate over vector each element's address
+ * @param it - iterator of type pointer to vector element
+ * @param vec - the vector
+ * @return void
+ */
+#define cvector_for_each_in(it, vec) \
+    for (it = cvector_begin(vec); it < cvector_end(vec); it++)
+
+/**
  * @brief cvector_for_each - call function func on each element of the vector
  * @param vec - the vector
  * @param func - function to be called on each element that takes each element as argument


### PR DESCRIPTION
Add function pointer that mimcs the element's destructor. The vector may be used with complex data structures that hold dynamically allocated memory. To prevent leaking this memory when elements are removed, I introduce a new field at the start of the cvector meta-data called `elem_destructor()`. Each time a element is removed, the function is called to prevent memory leaks. Initially, the function pointer is set to NULL. If that's the case, then no destructor is called, ensuring backwards compatibility.

This PR also already contains the commits from [PR 36](https://github.com/eteran/c-vector/pull/36), so please land this one first.

Here is the test I wrote to check the functionality:
```
jh@jh-ThinkPad-X250:~/GameDev/c-vector
$ cat test_changes.c
#include <stdio.h>
#include "cvector.h"

struct complex_struct {
	char *allocated_string;
	int i;
};

void free_fn(void *elem)
{
	struct complex_struct *a = elem;
	free(a->allocated_string);
}

int main() {
	cvector_vector_type(struct complex_struct) vec = NULL;

	struct complex_struct a = {
		.i = 10
	};

	a.allocated_string = strdup("hello World");
	cvector_push_back(vec, a);
	cvector_set_elem_destructor(vec, free_fn);

	a.allocated_string = strdup("hello github");
	a.i++;
	cvector_push_back(vec, a);

	printf("%d: %s\n", vec[0].i, vec[0].allocated_string);
	printf("%d: %s\n", vec[1].i, vec[1].allocated_string);

	cvector_pop_back(vec);
	cvector_free(vec);
}
jh@jh-ThinkPad-X250:~/GameDev/c-vector
$ gcc test_changes.c -g -Wall -Wextra -pedantic && valgrind ./a.out
==12953== Memcheck, a memory error detector
==12953== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==12953== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==12953== Command: ./a.out
==12953== 
10: hello World
11: hello github
==12953== 
==12953== HEAP SUMMARY:
==12953==     in use at exit: 0 bytes in 0 blocks
==12953==   total heap usage: 5 allocs, 5 frees, 1,145 bytes allocated
==12953== 
==12953== All heap blocks were freed -- no leaks are possible
==12953== 
==12953== For lists of detected and suppressed errors, rerun with: -s
==12953== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```