### PR TITLE
Issue 40: Fix alignment memory accesses

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,16 +9,16 @@ It works by using the same trick as many allocators, which is to slightly
 allocate more data than requested, and using that extra padding in the front
 as storage for meta-data. Thus any non-null vector looks like this in memory:
 
-	+------+----------+---------+
-	| size | capacity | data... |
-	+------+----------+---------+
-	                  ^
-	                  | user's pointer
+	+-----------------+------+----------+---------+
+	| elem_destructor | size | capacity | data... |
+	+-----------------+------+----------+---------+
+	                                    ^
+	                                    | user's pointer
 
 Where the user is given a pointer to first element of `data`. This way the
 code has trivial access to the necessary meta-data, but the user need not be
-concerned with these details. The total overhead is `2 * sizeof(size_t)` per
-vector.
+concerned with these details. The total overhead is
+`2 * sizeof(size_t) + sizeof(void (*)(void *))` per vector.
 
 To allow the code to be maximally generic, it is implemented as all macros, and
 is thus header only. Usage is simple:

--- a/cvector.h
+++ b/cvector.h
@@ -24,6 +24,8 @@
 #define cvector_clib_realloc realloc
 #endif
 
+typedef void (*cvector_elem_destructor_t)(void *elem);
+
 /**
  * @brief cvector_vector_type - The vector type used in this library
  */
@@ -44,6 +46,30 @@
  */
 #define cvector_size(vec) \
     ((vec) ? ((size_t *)(vec))[-2] : (size_t)0)
+
+/**
+ * @brief cvector_set_elem_destructor - set the element destructor function
+ * used to clean up removed elements
+ * @param vec - the vector
+ * @return elem_destructor_fn - function pointer of type cvector_elem_destructor_t
+ * @return the function pointer elem_destructor_fn or NULL on error
+ */
+#define cvector_set_elem_destructor(vec, elem_destructor_fn)                                \
+    do {                                                                                    \
+        if (!(vec)) {                                                                       \
+            cvector_grow((vec), 0);                                                         \
+        }                                                                                   \
+        ((cvector_elem_destructor_t *)&(((size_t *)(vec))[-2]))[-1] = (elem_destructor_fn); \
+    } while (0)
+
+/**
+ * @brief cvector_elem_destructor - get the element destructor function used
+ * to clean up elements
+ * @param vec - the vector
+ * @return the function pointer as cvector_elem_destructor_t
+ */
+#define cvector_elem_destructor(vec) \
+    ((vec) ? (((cvector_elem_destructor_t *)&(((size_t *)(vec))[-2]))[-1]) : NULL)
 
 /**
  * @brief cvector_empty - returns non-zero if the vector is empty
@@ -92,12 +118,18 @@
  * @param vec - the vector
  * @return void
  */
-#define cvector_free(vec)                        \
-    do {                                         \
-        if ((vec)) {                             \
-            size_t *p1 = &((size_t *)(vec))[-2]; \
-            cvector_clib_free(p1);               \
-        }                                        \
+#define cvector_free(vec)                                                                                                           \
+    do {                                                                                                                            \
+        if ((vec)) {                                                                                                                \
+            size_t *p1__                                = (size_t *)&(((cvector_elem_destructor_t *)&(((size_t *)(vec))[-2]))[-1]); \
+            cvector_elem_destructor_t elem_destructor__ = cvector_elem_destructor((vec));                                           \
+            if (elem_destructor__) {                                                                                                \
+                size_t i__;                                                                                                         \
+                for (i__ = 0; i__ < cvector_size(vec); ++i__)                                                                       \
+                    elem_destructor__(&vec[i__]);                                                                                   \
+            }                                                                                                                       \
+            cvector_clib_free(p1__);                                                                                                \
+        }                                                                                                                           \
     } while (0)
 
 /**
@@ -181,9 +213,12 @@
  * @param vec - the vector
  * @return void
  */
-#define cvector_pop_back(vec)                           \
-    do {                                                \
-        cvector_set_size((vec), cvector_size(vec) - 1); \
+#define cvector_pop_back(vec)                                                         \
+    do {                                                                              \
+        cvector_elem_destructor_t elem_destructor__ = cvector_elem_destructor((vec)); \
+        if (elem_destructor__)                                                        \
+            elem_destructor__(&(vec)[cvector_size(vec) - 1]);                         \
+        cvector_set_size((vec), cvector_size(vec) - 1);                               \
     } while (0)
 
 /**
@@ -233,22 +268,22 @@
  * @param count - the new capacity to set
  * @return void
  */
-#define cvector_grow(vec, count)                                                \
-    do {                                                                        \
-        const size_t cv_sz__ = (count) * sizeof(*(vec)) + (sizeof(size_t) * 2); \
-        if ((vec)) {                                                            \
-            size_t *cv_p1__ = &((size_t *)(vec))[-2];                           \
-            size_t *cv_p2__ = cvector_clib_realloc(cv_p1__, (cv_sz__));         \
-            assert(cv_p2__);                                                    \
-            (vec) = (void *)(&cv_p2__[2]);                                      \
-            cvector_set_capacity((vec), (count));                               \
-        } else {                                                                \
-            size_t *cv_p__ = cvector_clib_malloc(cv_sz__);                      \
-            assert(cv_p__);                                                     \
-            (vec) = (void *)(&cv_p__[2]);                                       \
-            cvector_set_capacity((vec), (count));                               \
-            cvector_set_size((vec), 0);                                         \
-        }                                                                       \
+#define cvector_grow(vec, count)                                                                                  \
+    do {                                                                                                          \
+        const size_t cv_sz__ = (count) * sizeof(*(vec)) + sizeof(size_t) * 2 + sizeof(cvector_elem_destructor_t); \
+        if ((vec)) {                                                                                              \
+            cvector_elem_destructor_t *cv_p1__ = &((cvector_elem_destructor_t *)&((size_t *)(vec))[-2])[-1];      \
+            cvector_elem_destructor_t *cv_p2__ = cvector_clib_realloc(cv_p1__, cv_sz__);                          \
+            assert(cv_p2__);                                                                                      \
+            (vec) = (void *)&((size_t *)&cv_p2__[1])[2];                                                          \
+        } else {                                                                                                  \
+            cvector_elem_destructor_t *cv_p__ = cvector_clib_malloc(cv_sz__);                                     \
+            assert(cv_p__);                                                                                       \
+            (vec) = (void *)&((size_t *)&cv_p__[1])[2];                                                           \
+            cvector_set_size((vec), 0);                                                                           \
+            ((cvector_elem_destructor_t *)&(((size_t *)(vec))[-2]))[-1] = NULL;                                   \
+        }                                                                                                         \
+        cvector_set_capacity((vec), (count));                                                                     \
     } while (0)
 
 #endif /* CVECTOR_H_ */

--- a/cvector_utils.h
+++ b/cvector_utils.h
@@ -2,6 +2,15 @@
 #define CVECTOR_UTILS_H_
 
 /**
+ * @brief cvector_for_each_in - for header to iterate over vector each element's address
+ * @param it - iterator of type pointer to vector element
+ * @param vec - the vector
+ * @return void
+ */
+#define cvector_for_each_in(it, vec) \
+    for (it = cvector_begin(vec); it < cvector_end(vec); it++)
+
+/**
  * @brief cvector_for_each - call function func on each element of the vector
  * @param vec - the vector
  * @param func - function to be called on each element that takes each element as argument


### PR DESCRIPTION
PR is still in early state. It's not fully tested and still buggy. Here is how I would try to tackle the issue https://github.com/eteran/c-vector/issues/40. I introduced several helper macros that help with the calculation.

The PR uses the macro `ALIGN_UP_TYPE(addr, type)`, which returns the aligned address `addr` to the type `type` if the `addr` is not aligned (see example at bottom).

Here is how I verified my changes.
```
$ cat test_changes.c 
#include <stdio.h>
#include <stdlib.h>
#include <stdint.h>
#include "cvector.h"

struct complex_struct {
	uint64_t i;
	char *allocated_string;
};

void free_fn(void *elem)
{
	struct complex_struct *a = elem;
	free(a->allocated_string);
}

int main() {
	cvector_vector_type(struct complex_struct) vec = NULL;

	struct complex_struct a = {
		10,
		NULL
	};

	a.allocated_string = strdup("hello World");
	cvector_push_back(vec, a);
	cvector_set_elem_destructor(vec, free_fn);

	a.allocated_string = strdup("hello github");
	a.i++;
	cvector_push_back(vec, a);

	printf("%lu: %s\n", vec[0].i, vec[0].allocated_string);
	printf("%lu: %s\n", vec[1].i, vec[1].allocated_string);
	printf("size offset: %lu\n", cvector_size_offset);
	printf("capcity offset: %lu\n", cvector_capacity_offset);
	printf("data offset: %lu\n", cvector_data_offset(vec));
	printf("sizeof(*data) = %lu\n", sizeof(*vec));
	printf("%p -> elem destructor %p\n", vec, &cvector_elem_destructor_rval(vec));

	cvector_pop_back(vec);
	cvector_free(vec);
}
jh@jh-ThinkPad-X250:~/GameDev/c-vector
$ gcc test_changes.c -g -Wall -Wextra -pedantic && valgrind ./a.out
test_changes.c: In function ‘main’:
test_changes.c:39:11: warning: format ‘%p’ expects argument of type ‘void *’, but argument 2 has type ‘struct complex_struct *’ [-Wformat=]
   39 |  printf("%p -> elem destructor %p\n", vec, &cvector_elem_destructor_rval(vec)); \
      |          ~^                           ~~~
      |           |                           |
      |           void *                      struct complex_struct *
test_changes.c:39:33: warning: format ‘%p’ expects argument of type ‘void *’, but argument 3 has type ‘void (**)(void *)’ [-Wformat=]
   39 |  printf("%p -> elem destructor %p\n", vec, &cvector_elem_destructor_rval(vec)); \
      |                                ~^
      |                                 |
      |                                 void *
==5308== Memcheck, a memory error detector
==5308== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==5308== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==5308== Command: ./a.out
==5308== 
10: hello World
11: hello github
size offset: 8
capcity offset: 16
data offset: 24
sizeof(*data) = 16
0x4a59168 -> elem destructor 0x4a59150
==5308== 
==5308== HEAP SUMMARY:
==5308==     in use at exit: 0 bytes in 0 blocks
==5308==   total heap usage: 5 allocs, 5 frees, 1,145 bytes allocated
==5308== 
==5308== All heap blocks were freed -- no leaks are possible
==5308== 
==5308== For lists of detected and suppressed errors, rerun with: -s
==5308== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

Here is my short test for the ALIGN_UP_TYPE macro:  
```
$ cat tmp.c 
#include <stdio.h>
#include <stdint.h>

#include "cvector.h"

int main()
{
	for (uint64_t i = 0; i < 30; ++i) {
		printf("align up %lu->%lu\n", i, ALIGN_UP_TYPE(i, uint64_t));
	}
	uint64_t *v = NULL;
	printf("%lu, %lu, %lu\n", sizeof (cvector_elem_destructor_t), sizeof(size_t), sizeof(uint64_t));
	printf("&0->capacity = %lu\n", cvector_capacity_offset);
	printf("&0->size = %lu\n", cvector_size_offset);
	printf("&0->data = %lu\n", cvector_data_offset(v));
}
jh@jh-ThinkPad-X250:~/GameDev/c-vector
$ gcc tmp.c -Wall -Wextra -pedantic -o test_align_up && ./test_align_up
align up 0->0
align up 1->8
align up 2->8
align up 3->8
align up 4->8
align up 5->8
align up 6->8
align up 7->8
align up 8->8
align up 9->16
align up 10->16
align up 11->16
align up 12->16
align up 13->16
align up 14->16
align up 15->16
align up 16->16
align up 17->24
align up 18->24
align up 19->24
align up 20->24
align up 21->24
align up 22->24
align up 23->24
align up 24->24
align up 25->32
align up 26->32
align up 27->32
align up 28->32
align up 29->32
8, 8, 8
&0->capacity = 16
&0->size = 8
&0->data = 24
```