### PR TITLE
Add copyright and license on the top of the cvector.h file

### DIFF
--- a/cvector.h
+++ b/cvector.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2015 Evan Teran
+ *
+ * License: The MIT License (MIT)
+ */
 
 #ifndef CVECTOR_H_
 #define CVECTOR_H_


### PR DESCRIPTION
For some people who want to use this library on the other project by just copying the file, need to add copyright on the top of the file.
If the copyright and the license are already specified on the top of the file, this library can be much easier to be used.

I'm trying to use cvector.h on other project.
https://github.com/iovisor/bcc/pull/4120
And one reviewer recommend me to add copyright notice on the cvector.h file.
I thinks this request is reasonable and it would be better to add the copyright notice on the main project.