### PR TITLE
Change grow to set_capactiy, add deep copy

### DIFF
--- a/cvector.h
+++ b/cvector.h
@@ -30,11 +30,13 @@
 #endif
 
 typedef void (*cvector_elem_destructor_t)(void *elem);
+typedef void (*cvector_elem_deep_copy_t)(void *elem_from, void *elem_to);
 
 typedef struct cvector_metadata_t {
     size_t size;
     size_t capacity;
     cvector_elem_destructor_t elem_destructor;
+    cvector_elem_deep_copy_t elem_deep_copy;
 } cvector_metadata_t;
 
 /**
@@ -84,6 +86,15 @@ typedef struct cvector_metadata_t {
     ((vec) ? cvector_vec_to_base(vec)->elem_destructor : NULL)
 
 /**
+ * @brief cvector_elem_deep_copy - get the element deep copy function used
+ * to make deep copies of elements
+ * @param vec - the vector
+ * @return the function pointer as cvector_elem_deep_copy_t
+ */
+#define cvector_elem_deep_copy(vec) \
+    ((vec) ? cvector_vec_to_base(vec)->elem_deep_copy : NULL)
+
+/**
  * @brief cvector_empty - returns non-zero if the vector is empty
  * @param vec - the vector
  * @return non-zero if empty, zero if non-empty
@@ -97,15 +108,15 @@ typedef struct cvector_metadata_t {
  * function causes the container to reallocate its storage increasing its
  * capacity to n (or greater).
  * @param vec - the vector
- * @param n - Minimum capacity for the vector.
+ * @param capacity - Minimum capacity for the vector.
  * @return void
  */
-#define cvector_reserve(vec, capacity)           \
-    do {                                         \
-        size_t cv_cap__ = cvector_capacity(vec); \
-        if (cv_cap__ < (capacity)) {             \
-            cvector_grow((vec), (capacity));     \
-        }                                        \
+#define cvector_reserve(vec, capacity)                   \
+    do {                                                 \
+        size_t cv_cap__ = cvector_capacity(vec);         \
+        if (cv_cap__ < (capacity)) {                     \
+            cvector_set_capacity((vec), (capacity));     \
+        }                                                \
     } while (0)
 
 /**
@@ -128,6 +139,60 @@ typedef struct cvector_metadata_t {
                     (vec) + (i),                                                            \
                     (vec) + (i) + 1,                                                        \
                     sizeof(*(vec)) * (cv_sz__ - 1 - (i)));                                  \
+            }                                                                               \
+        }                                                                                   \
+    } while (0)
+
+/**
+ * @brief cvector_erase_fast - Removes the element at index i from the vector by overwriting
+ * it with the last element in the vector.  This will change the order of the elements in
+ * the vector.
+ * @param vec - the vector
+ * @param i - index of element to remove
+ * @return void
+ */
+#define cvector_erase_fast(vec, i)                                                          \
+    do {                                                                                    \
+        if (vec) {                                                                          \
+            const size_t cv_sz__ = cvector_size(vec);                                       \
+            if ((i) < cv_sz__) {                                                            \
+                cvector_elem_destructor_t elem_destructor__ = cvector_elem_destructor(vec); \
+                if (elem_destructor__) {                                                    \
+                    elem_destructor__(&vec[i]);                                             \
+                }                                                                           \
+                vec[i] = vec[cv_sz__ - 1];                                                  \
+                cvector_set_size((vec), cv_sz__ - 1);                                       \
+            }                                                                               \
+        }                                                                                   \
+    } while (0)
+
+/**
+ * @brief cvector_erase_range - Removes count elements from the vector, starting with index i.
+ * If the specified range would exceed the size of the vector, elements will only be erased 
+ * to the end of the vector.
+ * @param vec - the vector
+ * @param i - first index of elements to remove
+ * @param count - the number of elements to remove
+ * @return void
+ */
+#define cvector_erase_range(vec, i, count)                                                  \
+    do {                                                                                    \
+        if (vec) {                                                                          \
+            const size_t cv_sz__ = cvector_size(vec);                                       \
+            if ((i) < cv_sz__) {                                                            \
+                size_t count__ = (i) + (count) > cv_sz__ ? cv_sz__ - (i) : (count);         \
+                cvector_elem_destructor_t elem_destructor__ = cvector_elem_destructor(vec); \
+                if (elem_destructor__) {                                                    \
+                    size_t i__;                                                             \
+                    for (i__ = (i); i__ < (i) + count__; ++i__) {                           \
+                        elem_destructor__(&vec[i__]);                                       \
+                    }                                                                       \
+                }                                                                           \
+                cvector_set_size((vec), cv_sz__ - count__);                                 \
+                memmove(                                                                    \
+                    (vec) + (i),                                                            \
+                    (vec) + (i) + count__,                                                  \
+                    sizeof(*(vec)) * (cv_sz__ - count__ - (i)));                            \
             }                                                                               \
         }                                                                                   \
     } while (0)
@@ -191,7 +256,7 @@ typedef struct cvector_metadata_t {
 #ifdef CVECTOR_LOGARITHMIC_GROWTH
 
 /**
- * @brief cvector_compute_next_grow - returns an the computed size in next vector grow
+ * @brief cvector_compute_next_grow - returns the computed size of the next vector grow
  * size is increased by multiplication of 2
  * @param size - current size
  * @return size after next vector grow
@@ -202,7 +267,7 @@ typedef struct cvector_metadata_t {
 #else
 
 /**
- * @brief cvector_compute_next_grow - returns an the computed size in next vector grow
+ * @brief cvector_compute_next_grow - returns the computed size of the next vector grow
  * size is increased by 1
  * @param size - current size
  * @return size after next vector grow
@@ -218,14 +283,14 @@ typedef struct cvector_metadata_t {
  * @param value - the value to add
  * @return void
  */
-#define cvector_push_back(vec, value)                                 \
-    do {                                                              \
-        size_t cv_cap__ = cvector_capacity(vec);                      \
-        if (cv_cap__ <= cvector_size(vec)) {                          \
-            cvector_grow((vec), cvector_compute_next_grow(cv_cap__)); \
-        }                                                             \
-        (vec)[cvector_size(vec)] = (value);                           \
-        cvector_set_size((vec), cvector_size(vec) + 1);               \
+#define cvector_push_back(vec, value)                                         \
+    do {                                                                      \
+        size_t cv_cap__ = cvector_capacity(vec);                              \
+        if (cv_cap__ <= cvector_size(vec)) {                                  \
+            cvector_set_capacity((vec), cvector_compute_next_grow(cv_cap__)); \
+        }                                                                     \
+        (vec)[cvector_size(vec)] = (value);                                   \
+        cvector_set_size((vec), cvector_size(vec) + 1);                       \
     } while (0)
 
 /**
@@ -235,20 +300,20 @@ typedef struct cvector_metadata_t {
  * @param val - value to be copied (or moved) to the inserted elements.
  * @return void
  */
-#define cvector_insert(vec, pos, val)                                 \
-    do {                                                              \
-        size_t cv_cap__ = cvector_capacity(vec);                      \
-        if (cv_cap__ <= cvector_size(vec)) {                          \
-            cvector_grow((vec), cvector_compute_next_grow(cv_cap__)); \
-        }                                                             \
-        if ((pos) < cvector_size(vec)) {                              \
-            memmove(                                                  \
-                (vec) + (pos) + 1,                                    \
-                (vec) + (pos),                                        \
-                sizeof(*(vec)) * ((cvector_size(vec)) - (pos)));      \
-        }                                                             \
-        (vec)[(pos)] = (val);                                         \
-        cvector_set_size((vec), cvector_size(vec) + 1);               \
+#define cvector_insert(vec, pos, val)                                         \
+    do {                                                                      \
+        size_t cv_cap__ = cvector_capacity(vec);                              \
+        if (cv_cap__ <= cvector_size(vec)) {                                  \
+            cvector_set_capacity((vec), cvector_compute_next_grow(cv_cap__)); \
+        }                                                                     \
+        if ((pos) < cvector_size(vec)) {                                      \
+            memmove(                                                          \
+                (vec) + (pos) + 1,                                            \
+                (vec) + (pos),                                                \
+                sizeof(*(vec)) * ((cvector_size(vec)) - (pos)));              \
+        }                                                                     \
+        (vec)[(pos)] = (val);                                                 \
+        cvector_set_size((vec), cvector_size(vec) + 1);                       \
     } while (0)
 
 /**
@@ -266,7 +331,10 @@ typedef struct cvector_metadata_t {
     } while (0)
 
 /**
- * @brief cvector_copy - copy a vector
+ * @brief cvector_copy - Copy a vector.  If the vector to be copied to has any elements in it,
+ * the vector will be cleared using cvector_clear.  If the vector to be copied to has a larger
+ * capacity than the vector being copied from, the vector being copied to will not change its
+ * capacity.
  * @param from - the original vector
  * @param to - destination to which the function copy to
  * @return void
@@ -274,23 +342,55 @@ typedef struct cvector_metadata_t {
 #define cvector_copy(from, to)                                          \
     do {                                                                \
         if ((from)) {                                                   \
-            cvector_grow(to, cvector_size(from));                       \
+            if ((to)) {                                                 \
+                cvector_clear(to);                                      \
+            }                                                           \
+            if (cvector_capacity(to) < cvector_capacity(from)) {        \
+                cvector_set_capacity(to, cvector_size(from));           \
+            }                                                           \
             cvector_set_size(to, cvector_size(from));                   \
             memcpy((to), (from), cvector_size(from) * sizeof(*(from))); \
         }                                                               \
     } while (0)
 
 /**
- * @brief cvector_set_capacity - For internal use, sets the capacity variable of the vector
- * @param vec - the vector
- * @param size - the new capacity to set
+ * @brief cvector_deep_copy - Copy a vector and any deeper memory associated with 
+ * the vector's elements.  The deep copy function must copy _everything_ in an element,
+ * as cvector will not copy anything here.
+ * @param from - the original vector
+ * @param to - destination vector to copy into
  * @return void
  */
-#define cvector_set_capacity(vec, size)                  \
-    do {                                                 \
-        if (vec) {                                       \
-            cvector_vec_to_base(vec)->capacity = (size); \
-        }                                                \
+#define cvector_deep_copy(from, to)                                                   \
+    do {                                                                              \
+        if ((from)) {                                                                 \
+            if ((to)) {                                                               \
+                cvector_clear(to);                                                    \
+            }                                                                         \
+            if (cvector_capacity(to) < cvector_capacity(from)) {                      \
+                cvector_set_capacity(to, cvector_size(from));                         \
+            }                                                                         \
+            cvector_set_size(to, cvector_size(from));                                 \
+            cvector_elem_deep_copy_t elem_deep_copy__ = cvector_elem_deep_copy(from); \
+            if (elem_deep_copy__) {                                                   \
+                size_t i__;                                                           \
+                for (i__ = 0; i__ < cvector_size(from); ++i__) {                      \
+                    elem_deep_copy__(&(from)[i__], &(to)[i__]);                       \
+                }                                                                     \
+            }                                                                         \
+            cvector_set_elem_destructor((to), cvector_elem_destructor(from));         \
+            cvector_set_elem_deep_copy((to), cvector_elem_deep_copy(from));           \
+        }                                                                             \
+    } while (0)
+
+/**
+ * @brief cvector_shrink_to_fit - Reduce the vector's capacity to match its current size
+ * @param vec - the vector
+ * @return void
+ */
+#define cvector_shrink_to_fit(vec)                    \
+    do {                                              \
+        cvector_set_capacity(vec, cvector_size(vec)); \
     } while (0)
 
 /**
@@ -321,27 +421,64 @@ typedef struct cvector_metadata_t {
     } while (0)
 
 /**
- * @brief cvector_grow - For internal use, ensures that the vector is at least <count> elements big
+ * @brief cvector_set_elem_deep_copy - set the element deep copy function
+ * used to make deep copies of elements
+ * @param vec - the vector
+ * @param elem_deep_copy_fn - function pointer of type cvector_elem_deep_copy_t used to make deep copies of elements
+ * @return void
+ */
+#define cvector_set_elem_deep_copy(vec, elem_deep_copy_fn)                    \
+    do {                                                                      \
+        if (vec) {                                                            \
+            cvector_vec_to_base(vec)->elem_deep_copy = (elem_deep_copy_fn);   \
+        }                                                                     \
+    } while (0)
+
+/**
+ * @brief cvector_init - Initialize a vector.  The vector must be NULL for this to do anything.
+ * @param vec - the vector
+ * @param capacity - vector capacity to reserve
+ * @param elem_destructor_fn - element destructor function
+ * @param elem_deep_copy_fn - element deep copy function
+ * @return void
+ */
+#define cvector_init(vec, capacity, elem_destructor_fn, elem_deep_copy_fn) \
+    do {                                                                   \
+        if (!(vec)) {                                                      \
+            cvector_set_capacity((vec), capacity);                         \
+            cvector_set_elem_destructor((vec), (elem_destructor_fn));      \
+            cvector_set_elem_deep_copy((vec), (elem_deep_copy_fn));        \
+        }                                                                  \
+    } while (0)
+
+/**
+ * @brief cvector_set_capacity - Set the vector's capacity to be at least <capacity> 
+ * elements big. If the new vector capacity is less than the current vector size, then 
+ * erase the elements at the end of the vector which would be beyond the new capacity.
  * @param vec - the vector
  * @param count - the new capacity to set
  * @return void
  */
-#define cvector_grow(vec, count)                                                      \
-    do {                                                                              \
-        const size_t cv_sz__ = (count) * sizeof(*(vec)) + sizeof(cvector_metadata_t); \
-        if (vec) {                                                                    \
-            void *cv_p1__ = cvector_vec_to_base(vec);                                 \
-            void *cv_p2__ = cvector_clib_realloc(cv_p1__, cv_sz__);                   \
-            assert(cv_p2__);                                                          \
-            (vec) = cvector_base_to_vec(cv_p2__);                                     \
-        } else {                                                                      \
-            void *cv_p__ = cvector_clib_malloc(cv_sz__);                              \
-            assert(cv_p__);                                                           \
-            (vec) = cvector_base_to_vec(cv_p__);                                      \
-            cvector_set_size((vec), 0);                                               \
-            cvector_set_elem_destructor((vec), NULL);                                 \
-        }                                                                             \
-        cvector_set_capacity((vec), (count));                                         \
+#define cvector_set_capacity(vec, capacity)                                              \
+    do {                                                                                 \
+        const size_t cv_sz__ = (capacity) * sizeof(*(vec)) + sizeof(cvector_metadata_t); \
+        if (vec) {                                                                       \
+            if (cvector_size(vec) > (capacity)) {                                        \
+                cvector_erase_range((vec), (capacity), cvector_size(vec) - (capacity));  \
+            }                                                                            \
+            void *cv_p1__ = cvector_vec_to_base(vec);                                    \
+            void *cv_p2__ = cvector_clib_realloc(cv_p1__, cv_sz__);                      \
+            assert(cv_p2__);                                                             \
+            (vec) = cvector_base_to_vec(cv_p2__);                                        \
+        } else {                                                                         \
+            void *cv_p__ = cvector_clib_malloc(cv_sz__);                                 \
+            assert(cv_p__);                                                              \
+            (vec) = cvector_base_to_vec(cv_p__);                                         \
+            cvector_set_size((vec), 0);                                                  \
+            cvector_set_elem_destructor((vec), NULL);                                    \
+            cvector_set_elem_deep_copy((vec), NULL);                                     \
+        }                                                                                \
+        cvector_vec_to_base(vec)->capacity = (capacity);                                 \
     } while (0)
 
 #endif /* CVECTOR_H_ */

--- a/cvector.h
+++ b/cvector.h
@@ -175,26 +175,26 @@ typedef struct cvector_metadata_t {
  * @param count - the number of elements to remove
  * @return void
  */
-#define cvector_erase_range(vec, i, count)                                                  \
-    do {                                                                                    \
-        if (vec) {                                                                          \
-            const size_t cv_sz__ = cvector_size(vec);                                       \
-            if ((i) < cv_sz__) {                                                            \
-                size_t count__ = (i) + (count) > cv_sz__ ? cv_sz__ - (i) : (count);         \
-                cvector_elem_destructor_t elem_destructor__ = cvector_elem_destructor(vec); \
-                if (elem_destructor__) {                                                    \
-                    size_t i__;                                                             \
-                    for (i__ = (i); i__ < (i) + count__; ++i__) {                           \
-                        elem_destructor__(&vec[i__]);                                       \
-                    }                                                                       \
-                }                                                                           \
-                cvector_set_size((vec), cv_sz__ - count__);                                 \
-                memmove(                                                                    \
-                    (vec) + (i),                                                            \
-                    (vec) + (i) + count__,                                                  \
-                    sizeof(*(vec)) * (cv_sz__ - count__ - (i)));                            \
-            }                                                                               \
-        }                                                                                   \
+#define cvector_erase_range(vec, i, count)                                                                       \
+    do {                                                                                                         \
+        if (vec) {                                                                                               \
+            const size_t cv_sz__ = cvector_size(vec);                                                            \
+            if ((i) < cv_sz__) {                                                                                 \
+                size_t count__                              = (i) + (count) > cv_sz__ ? cv_sz__ - (i) : (count); \
+                cvector_elem_destructor_t elem_destructor__ = cvector_elem_destructor(vec);                      \
+                if (elem_destructor__) {                                                                         \
+                    size_t i__;                                                                                  \
+                    for (i__ = (i); i__ < (i) + count__; ++i__) {                                                \
+                        elem_destructor__(&vec[i__]);                                                            \
+                    }                                                                                            \
+                }                                                                                                \
+                cvector_set_size((vec), cv_sz__ - count__);                                                      \
+                memmove(                                                                                         \
+                    (vec) + (i),                                                                                 \
+                    (vec) + (i) + count__,                                                                       \
+                    sizeof(*(vec)) * (cv_sz__ - count__ - (i)));                                                 \
+            }                                                                                                    \
+        }                                                                                                        \
     } while (0)
 
 /**

--- a/cvector.h
+++ b/cvector.h
@@ -459,26 +459,26 @@ typedef struct cvector_metadata_t {
  * @param count - the new capacity to set
  * @return void
  */
-#define cvector_set_capacity(vec, capacity)                                              \
-    do {                                                                                 \
-        const size_t cv_sz__ = (capacity) * sizeof(*(vec)) + sizeof(cvector_metadata_t); \
-        if (vec) {                                                                       \
-            if (cvector_size(vec) > (capacity)) {                                        \
-                cvector_erase_range((vec), (capacity), cvector_size(vec) - (capacity));  \
-            }                                                                            \
-            void *cv_p1__ = cvector_vec_to_base(vec);                                    \
-            void *cv_p2__ = cvector_clib_realloc(cv_p1__, cv_sz__);                      \
-            assert(cv_p2__);                                                             \
-            (vec) = cvector_base_to_vec(cv_p2__);                                        \
-        } else {                                                                         \
-            void *cv_p__ = cvector_clib_malloc(cv_sz__);                                 \
-            assert(cv_p__);                                                              \
-            (vec) = cvector_base_to_vec(cv_p__);                                         \
-            cvector_set_size((vec), 0);                                                  \
-            cvector_set_elem_destructor((vec), NULL);                                    \
-            cvector_set_elem_deep_copy((vec), NULL);                                     \
-        }                                                                                \
-        cvector_vec_to_base(vec)->capacity = (capacity);                                 \
+#define cvector_set_capacity(vec, count)                                              \
+    do {                                                                              \
+        const size_t cv_sz__ = (count) * sizeof(*(vec)) + sizeof(cvector_metadata_t); \
+        if (vec) {                                                                    \
+            if (cvector_size(vec) > (count)) {                                        \
+                cvector_erase_range((vec), (count), cvector_size(vec) - (count));     \
+            }                                                                         \
+            void *cv_p1__ = cvector_vec_to_base(vec);                                 \
+            void *cv_p2__ = cvector_clib_realloc(cv_p1__, cv_sz__);                   \
+            assert(cv_p2__);                                                          \
+            (vec) = cvector_base_to_vec(cv_p2__);                                     \
+        } else {                                                                      \
+            void *cv_p__ = cvector_clib_malloc(cv_sz__);                              \
+            assert(cv_p__);                                                           \
+            (vec) = cvector_base_to_vec(cv_p__);                                      \
+            cvector_set_size((vec), 0);                                               \
+            cvector_set_elem_destructor((vec), NULL);                                 \
+            cvector_set_elem_deep_copy((vec), NULL);                                  \
+        }                                                                             \
+        cvector_vec_to_base(vec)->capacity = (count);                                 \
     } while (0)
 
 #endif /* CVECTOR_H_ */

--- a/cvector.h
+++ b/cvector.h
@@ -111,12 +111,12 @@ typedef struct cvector_metadata_t {
  * @param capacity - Minimum capacity for the vector.
  * @return void
  */
-#define cvector_reserve(vec, capacity)                   \
-    do {                                                 \
-        size_t cv_cap__ = cvector_capacity(vec);         \
-        if (cv_cap__ < (capacity)) {                     \
-            cvector_set_capacity((vec), (capacity));     \
-        }                                                \
+#define cvector_reserve(vec, capacity)               \
+    do {                                             \
+        size_t cv_cap__ = cvector_capacity(vec);     \
+        if (cv_cap__ < (capacity)) {                 \
+            cvector_set_capacity((vec), (capacity)); \
+        }                                            \
     } while (0)
 
 /**
@@ -168,7 +168,7 @@ typedef struct cvector_metadata_t {
 
 /**
  * @brief cvector_erase_range - Removes count elements from the vector, starting with index i.
- * If the specified range would exceed the size of the vector, elements will only be erased 
+ * If the specified range would exceed the size of the vector, elements will only be erased
  * to the end of the vector.
  * @param vec - the vector
  * @param i - first index of elements to remove
@@ -354,7 +354,7 @@ typedef struct cvector_metadata_t {
     } while (0)
 
 /**
- * @brief cvector_deep_copy - Copy a vector and any deeper memory associated with 
+ * @brief cvector_deep_copy - Copy a vector and any deeper memory associated with
  * the vector's elements.  The deep copy function must copy _everything_ in an element,
  * as cvector will not copy anything here.
  * @param from - the original vector
@@ -427,11 +427,11 @@ typedef struct cvector_metadata_t {
  * @param elem_deep_copy_fn - function pointer of type cvector_elem_deep_copy_t used to make deep copies of elements
  * @return void
  */
-#define cvector_set_elem_deep_copy(vec, elem_deep_copy_fn)                    \
-    do {                                                                      \
-        if (vec) {                                                            \
-            cvector_vec_to_base(vec)->elem_deep_copy = (elem_deep_copy_fn);   \
-        }                                                                     \
+#define cvector_set_elem_deep_copy(vec, elem_deep_copy_fn)                  \
+    do {                                                                    \
+        if (vec) {                                                          \
+            cvector_vec_to_base(vec)->elem_deep_copy = (elem_deep_copy_fn); \
+        }                                                                   \
     } while (0)
 
 /**
@@ -452,8 +452,8 @@ typedef struct cvector_metadata_t {
     } while (0)
 
 /**
- * @brief cvector_set_capacity - Set the vector's capacity to be at least <capacity> 
- * elements big. If the new vector capacity is less than the current vector size, then 
+ * @brief cvector_set_capacity - Set the vector's capacity to be at least <capacity>
+ * elements big. If the new vector capacity is less than the current vector size, then
  * erase the elements at the end of the vector which would be beyond the new capacity.
  * @param vec - the vector
  * @param count - the new capacity to set

--- a/unit-tests.c
+++ b/unit-tests.c
@@ -249,8 +249,8 @@ UTEST(test, vector_erase_fast) {
     cvector_erase_fast(a, 2);
 
     ASSERT_TRUE(cvector_size(a) == 3);
-	 ASSERT_TRUE(a[1] == 5);
-	 ASSERT_TRUE(a[2] == 4);
+    ASSERT_TRUE(a[1] == 5);
+    ASSERT_TRUE(a[2] == 4);
 
     cvector_free(a);
 }
@@ -285,27 +285,25 @@ UTEST(test, vector_erase_range) {
 
 struct deep_t {
     int a;
-    int* b;
+    int *b;
 };
 
 // in the test, the b member of deep_t structs will always be treated as an int[3] array
-void copy (void *elem1, void *elem2)
-{
-    struct deep_t* element1 = (struct deep_t*) elem1;
-    struct deep_t* element2 = (struct deep_t*) elem2;
+void copy(void *elem1, void *elem2) {
+    struct deep_t *element1 = (struct deep_t *)elem1;
+    struct deep_t *element2 = (struct deep_t *)elem2;
 
-    element2->b = malloc (3 * sizeof (*element2->b));
+    element2->b = malloc(3 * sizeof(*element2->b));
 
-    element2->a = element1->a;
+    element2->a    = element1->a;
     element2->b[0] = element1->b[0];
     element2->b[1] = element1->b[1];
     element2->b[2] = element1->b[2];
 }
 
-void destructor (void *elem)
-{
-    struct deep_t* element = (struct deep_t*) elem;
-    free (element->b);
+void destructor(void *elem) {
+    struct deep_t *element = (struct deep_t *)elem;
+    free(element->b);
 }
 
 UTEST(test, vector_deep_copy) {
@@ -317,8 +315,8 @@ UTEST(test, vector_deep_copy) {
     deep.a = 2;
     cvector_push_back(from, deep);
 
-    from[0].b = malloc (3 * sizeof (*from[0].b));
-    from[1].b = malloc (3 * sizeof (*from[1].b));
+    from[0].b = malloc(3 * sizeof(*from[0].b));
+    from[1].b = malloc(3 * sizeof(*from[1].b));
 
     from[0].b[0] = 3;
     from[0].b[1] = 4;


### PR DESCRIPTION
remove cvector_set_capacity
    when would you ever want to change the capacity value without actually changing the capacity?

rename cvector_grow to cvector_set_capacity
    users can directly set the capacity of a vector (grow/shrink)

add deep copy function pointer to cvector_metadata_t
    used in cvector_deep_copy

add cvector_deep_copy
    cvector_copy does not copy anything pointed to by a vector element, cvector_deep_copy can

add cvector_elem_deep_copy
    get the deep copy function

add cvector_set_elem_deep_copy
    set the deep copy function

add cvector_erase_fast
add cvector_erase_range
add cvector_init
    save a few lines of code when declaring a new vector

add cvector_shrink_to_fit
    set vector capacity to vector size

cvector_copy will now erase 'to' if it has elements in it
cvector_copy will not change the capacity of 'to' if it is greater than the size of 'from'

add unit tests for some of the new macros
