### PR TITLE
Change parameter name same as description

### DIFF
--- a/cvector.h
+++ b/cvector.h
@@ -100,11 +100,11 @@ typedef struct cvector_metadata_t {
  * @param n - Minimum capacity for the vector.
  * @return void
  */
-#define cvector_reserve(vec, capacity)           \
+#define cvector_reserve(vec, n)                  \
     do {                                         \
         size_t cv_cap__ = cvector_capacity(vec); \
-        if (cv_cap__ < (capacity)) {             \
-            cvector_grow((vec), (capacity));     \
+        if (cv_cap__ < (n)) {                    \
+            cvector_grow((vec), (n));            \
         }                                        \
     } while (0)
 


### PR DESCRIPTION
The second parameter of `cvector_reserve` is `n` on the description but `capacity` on the source code.
Change it to `n` for unification.

It could be possible to change it to `capacity` for unification, I guess.