### PR TITLE
Fix destructor dereferencing

### DIFF
--- a/cvector.h
+++ b/cvector.h
@@ -136,7 +136,7 @@ typedef struct cvector_metadata_t {
             if ((i) < cv_sz__) {                                                            \
                 cvector_elem_destructor_t elem_destructor__ = cvector_elem_destructor(vec); \
                 if (elem_destructor__) {                                                    \
-                    elem_destructor__(&vec[i]);                                             \
+                    elem_destructor__(&(vec)[i]);                                           \
                 }                                                                           \
                 cvector_set_size((vec), cv_sz__ - 1);                                       \
                 memmove(                                                                    \
@@ -159,7 +159,7 @@ typedef struct cvector_metadata_t {
             if (elem_destructor__) {                                                    \
                 size_t i__;                                                             \
                 for (i__ = 0; i__ < cvector_size(vec); ++i__) {                         \
-                    elem_destructor__(&vec[i__]);                                       \
+                    elem_destructor__(&(vec)[i__]);                                     \
                 }                                                                       \
             }                                                                           \
             cvector_set_size(vec, 0);                                                   \
@@ -179,7 +179,7 @@ typedef struct cvector_metadata_t {
             if (elem_destructor__) {                                                    \
                 size_t i__;                                                             \
                 for (i__ = 0; i__ < cvector_size(vec); ++i__) {                         \
-                    elem_destructor__(&vec[i__]);                                       \
+                    elem_destructor__(&(vec)[i__]);                                     \
                 }                                                                       \
             }                                                                           \
             cvector_clib_free(p1__);                                                    \

--- a/unit-tests.c
+++ b/unit-tests.c
@@ -237,4 +237,25 @@ UTEST(test, test_complex_insert) {
     cvector_free(vec);
 }
 
+void cvector_free_destructor(void *p) {
+    free(*(void **)p);
+}
+
+UTEST(test, derefence_destructor) {
+    cvector_vector_type(char *) v = NULL;
+    cvector_init(v, 2, cvector_free_destructor);
+
+    char *ptr;
+    ptr = strdup("hello");
+    ASSERT_TRUE(!!ptr);
+    cvector_push_back(v, ptr);
+
+    ptr = strdup("world");
+    ASSERT_TRUE(!!ptr);
+    cvector_push_back(v, ptr);
+
+    cvector_vector_type(char *) *vec_ptr = &v;
+    cvector_free(*vec_ptr);
+}
+
 UTEST_MAIN();


### PR DESCRIPTION
* fix segfault caused by passing destructed value to `cvector_free` with `cvector_destructor`
* add unit test for dereferencing vector in cvector_destructor

-----

So, the problem was caused by code resembling the following:
```c
cvector_free(*vec_ptr);
```
This code expands to:
```c
&*vec_ptr[i]
```

This leads to an erroneous memory access and results in a segmentation fault.