### PR TITLE
Add cvector_at()

### DIFF
--- a/cvector.h
+++ b/cvector.h
@@ -296,6 +296,15 @@ typedef struct cvector_metadata_t {
     } while (0)
 
 /**
+ * @brief cvector_at - returns a reference to the element at specified location pos, with bounds checking
+ * @param vec - the vector
+ * @param pos - position of the element to return, as a size_t
+ * @return a pointer to the requested element (or NULL)
+ */
+#define cvector_at(vec, pos) \
+    ((vec) ? (((int)pos >= 0 && pos < cvector_size(vec)) ? &(vec)[pos] : NULL ) : NULL)
+
+/**
  * @brief cvector_set_capacity - For internal use, sets the capacity variable of the vector
  * @param vec - the vector
  * @param size - the new capacity to set

--- a/test.c
+++ b/test.c
@@ -143,6 +143,11 @@ int main() {
     assert(cvector_capacity(c) == 200);
     printf("c capacity: %zu\n", cvector_capacity(c));
     printf("c size        : %zu\n", cvector_size(c));
+
+    *cvector_at(c, 8) = 500;
+    assert(*cvector_at(c, 8) == 500);
+    assert(cvector_at(c, -100) == NULL);
+
     cvector_free(c);
 
     cvector_push_back(str_vect, strdup("Hello world"));

--- a/unit-tests.c
+++ b/unit-tests.c
@@ -96,6 +96,25 @@ UTEST(test, vector_index) {
     cvector_free(v);
 }
 
+UTEST(test, vector_at) {
+    cvector_vector_type(int) a = NULL;
+
+    cvector_push_back(a, 1);
+    cvector_push_back(a, 5);
+    cvector_push_back(a, 4);
+    cvector_push_back(a, 5);
+
+    ASSERT_EQ(*cvector_at(a, 0), 1);
+    ASSERT_EQ(*cvector_at(a, 1), 5);
+    ASSERT_EQ(*cvector_at(a, 2), 4);
+
+    ASSERT_EQ(cvector_at(NULL, 2), NULL);
+    ASSERT_EQ(cvector_at(a, 500), NULL);
+    ASSERT_EQ(cvector_at(a, -500), NULL);
+
+    cvector_free(a);
+}
+
 UTEST(test, vector_insert_delete) {
     cvector_vector_type(int) a = NULL;
 


### PR DESCRIPTION
https://cplusplus.com/reference/vector/vector/at/

This adds a `cvector_at()` function which aims to be implement [`std::vector::at()`](https://en.cppreference.com/w/cpp/container/vector/at). I'm not sure if the typecasting is correct, or even the approach. Would love some input.