### PR TITLE
Add cvector_iterator

### DIFF
--- a/cvector.h
+++ b/cvector.h
@@ -43,6 +43,11 @@ typedef struct cvector_metadata_t {
 #define cvector_vector_type(type) type *
 
 /**
+ * @brief cvector_iterator - The iterator type used for cvector
+ */
+#define cvector_iterator(type) cvector_vector_type(type)
+
+/**
  * @brief cvector_vec_to_base - For internal use, converts a vector pointer to a metadata pointer
  * @param vec - the vector
  * @return the metadata pointer of the vector

--- a/example.c
+++ b/example.c
@@ -42,7 +42,7 @@ int main(int argc, char *argv[]) {
 
     /* iterator over the vector using "iterator" style */
     if (v) {
-        int *it;
+        cvector_iterator(int) it;
         int i = 0;
         for (it = cvector_begin(v); it != cvector_end(v); ++it) {
             printf("v[%d] = %d\n", i, *it);

--- a/test.c
+++ b/test.c
@@ -34,7 +34,7 @@ int main() {
 
     /* iterator over the vector using "iterator" style */
     if (v) {
-        int *it;
+        cvector_iterator(int) it;
         int i = 0;
         for (it = cvector_begin(v); it != cvector_end(v); ++it) {
             printf("v[%d] = %d\n", i, *it);

--- a/unit-tests.c
+++ b/unit-tests.c
@@ -48,7 +48,7 @@ UTEST(test, vector_iterator) {
 
     /* iterator over the vector using "iterator" style */
     if (v) {
-        int *it;
+        cvector_iterator(int) it;
         int i = 0;
         for (it = cvector_begin(v); it != cvector_end(v); ++it) {
             switch (i) {
@@ -182,7 +182,7 @@ UTEST(test, vector_free_all) {
 }
 
 UTEST(test, vector_for_each_int) {
-    char **it;
+    cvector_iterator(char *) it;
     int i;
     cvector_vector_type(char *) v = NULL;
     for (i = 0; i < 10; ++i) {


### PR DESCRIPTION
This adds a `cvector_iterator(type)` to mimic `std::vector<type>::iterator`. Since it ends up being very similar to the original vector definition, I believe the syntax looks a bit nicer. It also ends up matching a bit of what C++ implements too, with the `::iterator` member.

I believe it's a bit easier to read.