### PR TITLE
Add cvector() syntactic sugar alias macro for cvector_vector_type()

### DIFF
--- a/cvector.h
+++ b/cvector.h
@@ -43,6 +43,13 @@ typedef struct cvector_metadata_t {
 #define cvector_vector_type(type) type *
 
 /**
+ * @brief cvector - Syntactic sugar to retrieve a vector type
+ *
+ * @param type The type of vector to act on.
+ */
+#define cvector(type) cvector_vector_type(type)
+
+/**
  * @brief cvector_vec_to_base - For internal use, converts a vector pointer to a metadata pointer
  * @param vec - the vector
  * @return the metadata pointer of the vector

--- a/example.c
+++ b/example.c
@@ -15,10 +15,10 @@ int main(int argc, char *argv[]) {
      * and you'd have a vector of floats :-). NULL will have a size
      * and capacity of 0. Additionally, vector_begin and vector_end will
      * return NULL on a NULL vector. Alternatively, for clarity of writing
-     * you can use the cvector_vector_type macro to define a vector of a
-     * given type.
+     * you can use the cvector or cvector_vector_type macros to define a
+     * vector of a given type.
      */
-    cvector_vector_type(int) v = NULL;
+    cvector(int) v = NULL;
 
     (void)argc;
     (void)argv;

--- a/unit-tests.c
+++ b/unit-tests.c
@@ -97,7 +97,7 @@ UTEST(test, vector_index) {
 }
 
 UTEST(test, vector_insert_delete) {
-    cvector_vector_type(int) a = NULL;
+    cvector(int) a = NULL;
 
     cvector_push_back(a, 1);
     cvector_push_back(a, 5);


### PR DESCRIPTION
I'm not sure if this is something you're interested in, but I find it makes the code a bit more readable...

``` c
cvector(int) v = NULL;
```