### PR TITLE
Make grow strategy per vector instead of global

### DIFF
--- a/unit-tests.c
+++ b/unit-tests.c
@@ -243,7 +243,7 @@ void cvector_free_destructor(void *p) {
 
 UTEST(test, derefence_destructor) {
     cvector_vector_type(char *) v = NULL;
-    cvector_init(v, 2, cvector_free_destructor);
+    cvector_init(v, 2, cvector_free_destructor, 0);
 
     char *ptr;
     ptr = strdup("hello");


### PR DESCRIPTION
1. Make grow strategy local per vector instead of using it globally
2. Add cast in cvector_reserve allowing to use signed integers as a parameter of the macro
