### PR TITLE
Add API documentation comparison to `std::vector`

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ int main(int argc, char *argv[]) {
 | [`v.shrink_to_fit()`](https://en.cppreference.com/w/cpp/container/vector/shrink_to_fit) | `cvector_shrink_to_fit(v)` |
 | [`v.clear()`](https://en.cppreference.com/w/cpp/container/vector/clear) | `cvector_clear(v)` |
 | [`v.insert(pos, value)`](https://en.cppreference.com/w/cpp/container/vector/insert) | `cvector_insert(v, pos, value)` |
-| [`v.erase(v.begin() + 2)`](https://en.cppreference.com/w/cpp/container/vector/erase) | `cvector_erase(3)` |
+| [`v.erase(v.begin() + 2)`](https://en.cppreference.com/w/cpp/container/vector/erase) | `cvector_erase(2)` |
 | [`v.push_back(value)`](https://en.cppreference.com/w/cpp/container/vector/push_back) | `cvector_push_back(v, value)` |
 | [`v.pop_back()`](https://en.cppreference.com/w/cpp/container/vector/pop_back) | `cvector_pop_back(v)` |
 | [`v.reserve(new_cap)`](https://en.cppreference.com/w/cpp/container/vector/reserve) | `cvector_reserve(v, new_cap)` |

--- a/README.md
+++ b/README.md
@@ -109,11 +109,9 @@ int main(int argc, char *argv[]) {
 | [`v.shrink_to_fit()`](https://en.cppreference.com/w/cpp/container/vector/shrink_to_fit) | `cvector_shrink_to_fit(v)` |
 | [`v.clear()`](https://en.cppreference.com/w/cpp/container/vector/clear) | `cvector_clear(v)` |
 | [`v.insert(pos, value)`](https://en.cppreference.com/w/cpp/container/vector/insert) | `cvector_insert(v, pos, value)` |
-| [`v.erase()`](https://en.cppreference.com/w/cpp/container/vector/erase) | `cvector_erase(v)` |
+| [`v.erase(v.begin() + 2)`](https://en.cppreference.com/w/cpp/container/vector/erase) | `cvector_erase(3)` |
 | [`v.push_back(value)`](https://en.cppreference.com/w/cpp/container/vector/push_back) | `cvector_push_back(v, value)` |
 | [`v.pop_back()`](https://en.cppreference.com/w/cpp/container/vector/pop_back) | `cvector_pop_back(v)` |
 | [`v.reserve(new_cap)`](https://en.cppreference.com/w/cpp/container/vector/reserve) | `cvector_reserve(v, new_cap)` |
 | [`v.swap(other)`](https://en.cppreference.com/w/cpp/container/vector/swap) | `cvector_swap(v, other)` |
 | [`std::vector<int> other = v;`](https://en.cppreference.com/w/cpp/named_req/CopyConstructible) | `cvector(int) other; cvector_copy(v, other);` |
-
-

--- a/README.md
+++ b/README.md
@@ -90,3 +90,30 @@ int main(int argc, char *argv[]) {
 }
 
 ```
+
+### API
+
+| `std::vector` | `cvector` |
+| ------------- | --------- |
+| [`std::vector<int> v`](https://en.cppreference.com/w/cpp/container/vector/vector) | `cvector(int) v` |
+| [Destructor](https://en.cppreference.com/w/cpp/container/vector/%7Evector) | `cvector_free(v)` |
+| [`v.at(3)`](https://en.cppreference.com/w/cpp/container/vector/at) | `cvector_at(v, 3)` |
+| [`v[3]`](https://en.cppreference.com/w/cpp/container/vector/operator_at) | `v[3]` |
+| [`v.front()`](https://en.cppreference.com/w/cpp/container/vector/front) | `cvector_front(v)` |
+| [`v.back()`](https://en.cppreference.com/w/cpp/container/vector/back) | `cvector_back(v)` |
+| [`v.begin()`](https://en.cppreference.com/w/cpp/container/vector/begin) | `cvector_begin(v)` |
+| [`v.end()`](https://en.cppreference.com/w/cpp/container/vector/begin) | `cvector_end(v)` |
+| [`v.empty()`](https://en.cppreference.com/w/cpp/container/vector/empty) | `cvector_empty(v)` |
+| [`v.size()`](https://en.cppreference.com/w/cpp/container/vector/size) | `cvector_size(v)` |
+| [`v.capacity()`](https://en.cppreference.com/w/cpp/container/vector/capacity) | `cvector_capacity(v)` |
+| [`v.shrink_to_fit()`](https://en.cppreference.com/w/cpp/container/vector/shrink_to_fit) | `cvector_shrink_to_fit(v)` |
+| [`v.clear()`](https://en.cppreference.com/w/cpp/container/vector/clear) | `cvector_clear(v)` |
+| [`v.insert(pos, value)`](https://en.cppreference.com/w/cpp/container/vector/insert) | `cvector_insert(v, pos, value)` |
+| [`v.erase()`](https://en.cppreference.com/w/cpp/container/vector/erase) | `cvector_erase(v)` |
+| [`v.push_back(value)`](https://en.cppreference.com/w/cpp/container/vector/push_back) | `cvector_push_back(v, value)` |
+| [`v.pop_back()`](https://en.cppreference.com/w/cpp/container/vector/pop_back) | `cvector_pop_back(v)` |
+| [`v.reserve(new_cap)`](https://en.cppreference.com/w/cpp/container/vector/reserve) | `cvector_reserve(v, new_cap)` |
+| [`v.swap(other)`](https://en.cppreference.com/w/cpp/container/vector/swap) | `cvector_swap(v, other)` |
+| [`std::vector<int> other = v;`](https://en.cppreference.com/w/cpp/named_req/CopyConstructible) | `cvector(int) other; cvector_copy(v, other);` |
+
+

--- a/cvector.h
+++ b/cvector.h
@@ -70,6 +70,7 @@ typedef struct cvector_metadata_t {
  * @brief cvector_vec_to_base - For internal use, converts a vector pointer to a metadata pointer
  * @param vec - the vector
  * @return the metadata pointer of the vector
+ * @internal
  */
 #define cvector_vec_to_base(vec) \
     (&((cvector_metadata_t *)(vec))[-1])
@@ -78,6 +79,7 @@ typedef struct cvector_metadata_t {
  * @brief cvector_base_to_vec - For internal use, converts a metadata pointer to a vector pointer
  * @param ptr - pointer to the metadata
  * @return the vector
+ * @internal
  */
 #define cvector_base_to_vec(ptr) \
     ((void *)&((cvector_metadata_t *)(ptr))[1])
@@ -340,6 +342,7 @@ typedef struct cvector_metadata_t {
  * @param vec - the vector
  * @param size - the new capacity to set
  * @return void
+ * @internal
  */
 #define cvector_set_capacity(vec, size)                  \
     do {                                                 \
@@ -353,6 +356,7 @@ typedef struct cvector_metadata_t {
  * @param vec - the vector
  * @param size - the new capacity to set
  * @return void
+ * @internal
  */
 #define cvector_set_size(vec, _size)                  \
     do {                                              \
@@ -380,6 +384,7 @@ typedef struct cvector_metadata_t {
  * @param vec - the vector
  * @param count - the new capacity to set
  * @return void
+ * @internal
  */
 #define cvector_grow(vec, count)                                                      \
     do {                                                                              \


### PR DESCRIPTION
I'm unsure if this is something that you're considering, but I've added a table with comparison equivalents to `std::vector` at the bottom of README.md. May be a useful reference when looking for implementation details.

Also adds some `@internal` doxygen notes for the functions that are internal.

[Preview](https://github.com/RobLoach/c-vector/tree/api-docs?tab=readme-ov-file#api)