### PR TITLE
Fix strict warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ PUBLIC
 )
 
 set_target_properties(c-vector-example PROPERTIES C_STANDARD 90)
-target_compile_options(c-vector-example PUBLIC -Wall -Wextra)
+target_compile_options(c-vector-example PUBLIC -Wall -Werror -Wextra)
 
 # ----------------------------
 
@@ -35,7 +35,7 @@ add_executable(test-c-vector
 
 add_test(NAME test-c-vector COMMAND test-c-vector)
 set_target_properties(test-c-vector PROPERTIES C_STANDARD 90)
-target_compile_options(test-c-vector PUBLIC -Wall -Wextra)
+target_compile_options(test-c-vector PUBLIC -Wall -Werror -Wextra)
 
 add_test(test_build
   "${CMAKE_COMMAND}"
@@ -69,7 +69,7 @@ add_executable(unit-tests
 
 add_test(NAME unit-tests COMMAND $<TARGET_FILE:unit-tests>)
 set_target_properties(unit-tests PROPERTIES C_STANDARD 90)
-target_compile_options(unit-tests PUBLIC -Wall -Wextra)
+target_compile_options(unit-tests PUBLIC -Wall -Werror -Wextra)
 
 add_test(unit_test_build
   "${CMAKE_COMMAND}"

--- a/cvector.h
+++ b/cvector.h
@@ -419,7 +419,7 @@ typedef struct cvector_metadata_t {
  * @return the element at the specified position in the vector.
  */
 #define cvector_at(vec, n) \
-    ((vec) ? ((n < 0 || n >= cvector_size(vec)) ? NULL : &(vec)[n]) : NULL)
+    ((vec) ? (((int)(n) < 0 || (size_t)(n) >= cvector_size(vec)) ? NULL : &(vec)[n]) : NULL) \
 
 /**
  * @brief cvector_front - returns a reference to the first element in the vector. Unlike member cvector_begin, which returns an iterator to this same element, this function returns a direct reference.

--- a/cvector.h
+++ b/cvector.h
@@ -419,7 +419,7 @@ typedef struct cvector_metadata_t {
  * @return the element at the specified position in the vector.
  */
 #define cvector_at(vec, n) \
-    ((vec) ? (((int)(n) < 0 || (size_t)(n) >= cvector_size(vec)) ? NULL : &(vec)[n]) : NULL) \
+    ((vec) ? (((int)(n) < 0 || (size_t)(n) >= cvector_size(vec)) ? NULL : &(vec)[n]) : NULL)
 
 /**
  * @brief cvector_front - returns a reference to the first element in the vector. Unlike member cvector_begin, which returns an iterator to this same element, this function returns a direct reference.

--- a/unit-tests.c
+++ b/unit-tests.c
@@ -54,7 +54,7 @@ UTEST(test, vector_at) {
 
     if (v) {
         int i = 0;
-        for (; i < cvector_size(v); i++) {
+        for (; i < (int)cvector_size(v); i++) {
             ASSERT_TRUE(*cvector_at(v, i) == i);
         }
     }


### PR DESCRIPTION
This applies warnings-as-errors in the build, and fixes the comparision warnings as listed below.

```
In file included from /c-vector/example.c:8:
/c-vector/example.c: In function ‘main’:
/c-vector/cvector.h:422:18: error: comparison of unsigned expression in ‘< 0’ is always false [-Werror=type-limits]
  422 |     ((vec) ? ((n < 0 || n >= cvector_size(vec)) ? NULL : &(vec)[n]) : NULL)
      |                  ^
/c-vector/cvector.h:436:41: note: in expansion of macro ‘cvector_at’
  436 |     ((vec) ? ((cvector_size(vec) > 0) ? cvector_at(vec, cvector_size(vec) - 1) : NULL) : NULL)
      |                                         ^~~~~~~~~~
/c-vector/example.c:41:17: note: in expansion of macro ‘cvector_back’
   41 |     int *back = cvector_back(v);
      |                 ^~~~~~~~~~~~
/c-vector/cvector.h:422:18: error: comparison of unsigned expression in ‘< 0’ is always false [-Werror=type-limits]
  422 |     ((vec) ? ((n < 0 || n >= cvector_size(vec)) ? NULL : &(vec)[n]) : NULL)
      |                  ^
/c-vector/cvector.h:436:41: note: in expansion of macro ‘cvector_at’
  436 |     ((vec) ? ((cvector_size(vec) > 0) ? cvector_at(vec, cvector_size(vec) - 1) : NULL) : NULL)
      |                                         ^~~~~~~~~~
/c-vector/example.c:47:12: note: in expansion of macro ‘cvector_back’
   47 |     back = cvector_back(v);
      |            ^~~~~~~~~~~~
cc1: all warnings being treated as errors
make[2]: *** [CMakeFiles/c-vector-example.dir/build.make:76: CMakeFiles/c-vector-example.dir/example.c.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:85: CMakeFiles/c-vector-example.dir/all] Error 2
make: *** [Makefile:101: all] Error 2
```
