### PR TITLE
Update CMakeList for Windows build and CI test

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -58,6 +58,19 @@ jobs:
       run: |
         make test
 
+  windows-latest:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Configure CMake
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+    - name: Build
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+    - name: Test
+      working-directory: ${{github.workspace}}/build
+      run: |
+        ctest -C ${{env.BUILD_TYPE}}
+
   clang-format-checking:
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -57,18 +57,13 @@ build
 
 !.vscode/*.code-snippets
 ZERO_CHECK.*
-unit-tests.*
-test-c-vector.*
 RUN_TESTS.*
-c-vector.sln
-c-vector-example.*
-ALL_BUILD.vcxproj.*
-ALL_BUILD.vcxproj
-c-vector-example.dir
+ALL_BUILD.*
 Debug
-test-c-vector.dir
-unit-tests.dir
 x64
+*.dir
+test-*
+c-vector.sln
+c-vector-*
 unit-tests
-test-c-vector
-c-vector-example
+unit-tests.*

--- a/.gitignore
+++ b/.gitignore
@@ -69,7 +69,6 @@ Debug
 test-c-vector.dir
 unit-tests.dir
 x64
-.gitignore
 unit-tests
 test-c-vector
 c-vector-example

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,20 @@ build
 !.vscode/extensions.json
 
 !.vscode/*.code-snippets
+ZERO_CHECK.*
+unit-tests.*
+test-c-vector.*
+RUN_TESTS.*
+c-vector.sln
+c-vector-example.*
+ALL_BUILD.vcxproj.*
+ALL_BUILD.vcxproj
+c-vector-example.dir
+Debug
+test-c-vector.dir
+unit-tests.dir
+x64
+.gitignore
+unit-tests
+test-c-vector
+c-vector-example

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,9 @@
-cmake_minimum_required(VERSION 3.7.0)
+cmake_minimum_required(VERSION 3.7...3.14)
+
+if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")
+    cmake_policy(SET CMP0135 NEW)
+endif()
+
 project(c-vector VERSION 0.1.0)
 enable_testing()
 
@@ -23,7 +28,10 @@ PUBLIC
 )
 
 set_target_properties(c-vector-example PROPERTIES C_STANDARD 90)
-target_compile_options(c-vector-example PUBLIC -Wall -Werror -Wextra)
+
+if(UNIX)
+    target_compile_options(c-vector-example PUBLIC -Wall -Werror -Wextra)
+endif()
 
 # ----------------------------
 
@@ -35,12 +43,14 @@ add_executable(test-c-vector
 
 add_test(NAME test-c-vector COMMAND test-c-vector)
 set_target_properties(test-c-vector PROPERTIES C_STANDARD 90)
-target_compile_options(test-c-vector PUBLIC -Wall -Werror -Wextra)
+if(UNIX)
+    target_compile_options(test-c-vector PUBLIC -Wall -Werror -Wextra)
+endif()
 
 add_test(test_build
   "${CMAKE_COMMAND}"
   --build "${CMAKE_BINARY_DIR}"
-  --config "$<CONFIG>"
+  --config "${CMAKE_BUILD_TYPE}"
   --target test-c-vector
 )
 set_tests_properties(test_build PROPERTIES FIXTURES_SETUP    test_fixture)
@@ -69,14 +79,17 @@ add_executable(unit-tests
 
 add_test(NAME unit-tests COMMAND $<TARGET_FILE:unit-tests>)
 set_target_properties(unit-tests PROPERTIES C_STANDARD 90)
-target_compile_options(unit-tests PUBLIC -Wall -Werror -Wextra)
+if(UNIX)
+    target_compile_options(unit-tests PUBLIC -Wall -Werror -Wextra)
+endif()
 
 add_test(unit_test_build
   "${CMAKE_COMMAND}"
   --build "${CMAKE_BINARY_DIR}"
-  --config "$<CONFIG>"
+  --config "${CMAKE_BUILD_TYPE}"
   --target unit-tests
 )
+
 set_tests_properties(unit_test_build PROPERTIES FIXTURES_SETUP test_fixture)
 set_tests_properties(unit-tests PROPERTIES FIXTURES_REQUIRED test_fixture)
 


### PR DESCRIPTION
Great work! 

I had a different vector construction setup, then came across your feature for regular array index access. I scraped/refactored my version in https://github.com/zelang-dev/c-raii/tree/main/src/vector.c to use yours exclusively, memory usage cleanup is automatic though, RAII.

There are a few ideas to make c-vector more expandable, like adding an `enum` type field to `vector_metadata_t`, macro to set/get.