### PR TITLE
refactor cvector_at

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.7.0)
-project(c-vector VERSION 0.1.0)
+project(c-vector LANGUAGES C VERSION 0.1.0)
 enable_testing()
 
 # ------ cvector library ------

--- a/cvector.h
+++ b/cvector.h
@@ -434,21 +434,21 @@ typedef struct cvector_metadata_t {
  * @return the element at the specified position in the vector.
  */
 #define cvector_at(vec, n) \
-    ((vec) ? (((int)(n) < 0 || (size_t)(n) >= cvector_size(vec)) ? NULL : &(vec)[n]) : NULL)
+    ((vec)[(cvector_clib_assert((vec) && (ptrdiff_t)(n) < (ptrdiff_t)cvector_size(vec)), (n))])
 
 /**
  * @brief cvector_front - returns a reference to the first element in the vector. Unlike member cvector_begin, which returns an iterator to this same element, this function returns a direct reference.
  * @return a reference to the first element in the vector container.
  */
 #define cvector_front(vec) \
-    ((vec) ? ((cvector_size(vec) > 0) ? cvector_at(vec, 0) : NULL) : NULL)
+    (cvector_at(vec, 0))
 
 /**
  * @brief cvector_back - returns a reference to the last element in the vector.Unlike member cvector_end, which returns an iterator just past this element, this function returns a direct reference.
  * @return a reference to the last element in the vector.
  */
 #define cvector_back(vec) \
-    ((vec) ? ((cvector_size(vec) > 0) ? cvector_at(vec, cvector_size(vec) - 1) : NULL) : NULL)
+    (cvector_at(vec, cvector_size(vec) - 1))
 
 /**
  * @brief cvector_resize - resizes the container to contain count elements.

--- a/cvector.h
+++ b/cvector.h
@@ -40,6 +40,7 @@
 #include <string.h> /* for memmove */
 #define cvector_clib_memmove memmove
 #endif
+#include <stddef.h> /* for size_t, ptrdiff_t */
 
 /* NOTE: Similar to C's qsort and bsearch, you will receive a T*
  * for a vector of Ts. This means that you cannot use `free` directly

--- a/example.c
+++ b/example.c
@@ -32,20 +32,20 @@ int main(int argc, char *argv[]) {
     /* remove an element by specifying an array subscript */
     cvector_erase(v, 2);
 
-    int *twenty = cvector_at(v, 1);
-    printf("twenty : %d\n", *twenty);
+    int twenty = cvector_at(v, 1);
+    printf("twenty : %d\n", twenty);
 
-    int *front = cvector_front(v);
-    printf("front : %d\n", *front);
+    int front = cvector_front(v);
+    printf("front : %d\n", front);
 
-    int *back = cvector_back(v);
-    printf("back : %d\n", *back);
+    int back = cvector_back(v);
+    printf("back : %d\n", back);
 
     /* remove an element from the back */
     cvector_pop_back(v);
 
     back = cvector_back(v);
-    printf("back val after pop_back: %d\n", *back);
+    printf("back val after pop_back: %d\n", back);
 
     /* print out some stats about the vector */
     printf("pointer : %p\n", (void *)v);

--- a/unit-tests.c
+++ b/unit-tests.c
@@ -26,13 +26,11 @@ UTEST(test, cvector_back) {
 
     ASSERT_TRUE(cvector_size(v) == 2);
 
-    int *back = cvector_back(v);
-    ASSERT_TRUE(*back == 1);
+    ASSERT_TRUE(cvector_back(v) == 1);
 
     cvector_push_back(v, 2);
 
-    back = cvector_back(v);
-    ASSERT_TRUE(*back == 2);
+    ASSERT_TRUE(cvector_back(v) == 2);
 
     cvector_free(v);
 }
@@ -44,12 +42,10 @@ UTEST(test, cvector_front) {
 
     ASSERT_TRUE(cvector_size(v) == 2);
 
-    int *front = cvector_front(v);
-    ASSERT_TRUE(*front == 0);
+    ASSERT_TRUE(cvector_front(v) == 0);
 
     cvector_erase(v, 0);
-    front = cvector_front(v);
-    ASSERT_TRUE(*front == 1);
+    ASSERT_TRUE(cvector_front(v) == 1);
 
     cvector_free(v);
 }
@@ -67,17 +63,9 @@ UTEST(test, vector_at) {
     if (v) {
         int i = 0;
         for (; i < (int)cvector_size(v); i++) {
-            ASSERT_TRUE(*cvector_at(v, i) == i);
+            ASSERT_TRUE(cvector_at(v, i) == i);
         }
     }
-
-    /* test non-exists position */
-    int pos_non_exists = 999;
-    ASSERT_TRUE(cvector_at(v, pos_non_exists) == NULL);
-
-    /* remove last element*/
-    cvector_pop_back(v);
-    ASSERT_TRUE(cvector_at(v, 4) == NULL);
 
     cvector_free(v);
 }
@@ -364,7 +352,7 @@ struct data_t **test(size_t count, ...) {
 
     for (i = 0; i < count; i++) {
         int num             = va_arg(valist, int);
-        struct data_t *data = calloc(sizeof(struct data_t), 1);
+        struct data_t *data = calloc(1, sizeof(struct data_t));
         data->num           = num;
         cvector_insert(vec, 0, data);
     }


### PR DESCRIPTION
After I closed my issue, I suddenly had an idea.

Now, `cvector_at` can be used as follow:
```c
#include "cvector.h"
#include <stdio.h>
#include <assert.h>

int main(void) {
    cvector(int) v = NULL;
    cvector_push_back(v, 1);

    printf("%d\n", cvector_at(v, 0)); // get value
    cvector_at(v, 0) = 2; // set value
    printf("%d\n", cvector_at(v, 0));
    // printf("%d\n", cvector_at(v, 1)); // assert fail

    return 0;
}
```