### PR TITLE
Replace CVECTOR_LOGARITHMIC_GROWTH with CVECTOR_LINEAR_GROWTH

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,12 @@ concerned with these details. The total overhead is
 To allow the code to be maximally generic, it is implemented as all macros, and
 is thus header only. Usage is simple:
 ```c
-/* if this is defined, then the vector will double in capacity each
- * time it runs out of space. if it is not defined, then the vector will
- * be conservative, and will have a capcity no larger than necessary.
- * having this defined will minimize how often realloc gets called.
+/* if this is defined, then the vector will increase in capacity by one
+ * each time it runs out of space. if it is not defined, then the vector will
+ * be liberal, and will double in capacity each time it runs out of space.
+ * having this defined will minimize how much unused space is allocated.
  */
-#define CVECTOR_LOGARITHMIC_GROWTH
+#define CVECTOR_LINEAR_GROWTH
 
 #include "cvector.h"
 #include <stdio.h>

--- a/cvector.h
+++ b/cvector.h
@@ -238,19 +238,8 @@ typedef struct cvector_metadata_t {
 #define cvector_end(vec) \
     ((vec) ? &((vec)[cvector_size(vec)]) : NULL)
 
-/* user request to use logarithmic growth algorithm */
-#ifdef CVECTOR_LOGARITHMIC_GROWTH
-
-/**
- * @brief cvector_compute_next_grow - returns an the computed size in next vector grow
- * size is increased by multiplication of 2
- * @param size - current size
- * @return size after next vector grow
- */
-#define cvector_compute_next_grow(size) \
-    ((size) ? ((size) << 1) : 1)
-
-#else
+/* user request to use linear growth algorithm */
+#ifdef CVECTOR_LINEAR_GROWTH
 
 /**
  * @brief cvector_compute_next_grow - returns an the computed size in next vector grow
@@ -261,7 +250,18 @@ typedef struct cvector_metadata_t {
 #define cvector_compute_next_grow(size) \
     ((size) + 1)
 
-#endif /* CVECTOR_LOGARITHMIC_GROWTH */
+#else
+
+/**
+ * @brief cvector_compute_next_grow - returns an the computed size in next vector grow
+ * size is increased by multiplication of 2
+ * @param size - current size
+ * @return size after next vector grow
+ */
+#define cvector_compute_next_grow(size) \
+    ((size) ? ((size) << 1) : 1)
+
+#endif /* CVECTOR_LINEAR_GROWTH */
 
 /**
  * @brief cvector_push_back - adds an element to the end of the vector

--- a/example.c
+++ b/example.c
@@ -1,9 +1,9 @@
-/* if this is defined, then the vector will double in capacity each
- * time it runs out of space. if it is not defined, then the vector will
- * be conservative, and will have a capacity no larger than necessary.
- * having this defined will minimize how often realloc gets called.
+/* if this is defined, then the vector will increase in capacity by one
+ * each time it runs out of space. if it is not defined, then the vector will
+ * be liberal, and will double in capacity each time it runs out of space.
+ * having this defined will minimize how much unused space is allocated.
  */
-#define CVECTOR_LOGARITHMIC_GROWTH
+#define CVECTOR_LINEAR_GROWTH
 
 #include "cvector.h"
 #include <stdio.h>

--- a/test.c
+++ b/test.c
@@ -7,8 +7,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#define CVECTOR_LOGARITHMIC_GROWTH
-
 #include "cvector.h"
 #include "cvector_utils.h"
 

--- a/unit-tests.c
+++ b/unit-tests.c
@@ -1,6 +1,5 @@
 
 
-#define CVECTOR_LOGARITHMIC_GROWTH
 #include "cvector.h"
 #include "cvector_utils.h"
 #include "utest/utest.h"


### PR DESCRIPTION
In my own usage and in the examples I can find with using this library, it is more common to want to use the logarithmic growth algorithm than the linear growth algorithm. This is also the default (or only option) with vector and dynamic array data structures that are available in other programming languages. Setting the logarithmic algorithm to the default will reduce the burden on library users to define a special value in each compilation unit they use the library, and reduce the risk that they will forget to define it and lose performance.

This change is backwards compatible with any existing programs that defined the CVECTOR_LOGARITHMIC_GROWTH value; their program will continue to operate as intended, and they can remove the definition if/when they want.

This change *will* modify the behavior of programs that did not define the CVECTOR_LOGARITHMIC_GROWTH value; they must update their program to define the new CVECTOR_LINEAR_GROWTH value instead. However, given the small size of this library, I suspect that most users vendor the code directly into their codebases and will therefore not see any unexpected behavior. This change will only effect those that manually update their repository.