### PR TITLE
make GitHub recognize headers as C code

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.h linguist-language=C


### PR DESCRIPTION
The .h extension is ambiguous. However, it's quite misleading if GitHub's Linguist tags the whole repo as C++ because of that.